### PR TITLE
Add capability-aware backend routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,80 @@ pools:
 
 Rollback is just a config change: set `scheduler` back to `round-robin` for the pool and redeploy. Leaving `weight` values in place is safe because the default scheduler ignores them.
 
+## Capability-Aware Routing
+
+Jobs can further narrow backend selection with optional capability filters on the allocation request:
+
+- `required_capabilities`: every listed tag must be advertised by the backend
+- `excluded_capabilities`: none of the listed tags may be advertised by the backend
+- Capability matching is case-insensitive and uses normalized string tags
+- If neither field is set, broker behavior is unchanged
+
+Capability filtering happens before the pool scheduler runs. The scheduler registry stays unchanged and only sees the eligible backends that remain after filtering.
+
+Backend capability tags are configured per pool:
+
+```yaml
+pools:
+  - name: lite
+    scheduler: weighted-round-robin
+    backends:
+      arc:
+        enabled: true
+        maxRunners: 2
+        capabilities:
+          - cluster-local
+          - docker
+          - region:local
+      lambda:
+        enabled: true
+        maxRunners: 3
+        capabilities:
+          - region:aws-us-east-1
+      cloud-run:
+        enabled: true
+        maxRunners: 2
+        capabilities:
+          - region:gcp-us-central1
+```
+
+Examples:
+
+- Cluster-local routing:
+
+```yaml
+- uses: ./actions/allocate-runner
+  with:
+    broker_url: https://broker.example.com
+    pool: lite
+    required_capabilities: cluster-local
+```
+
+- GPU routing:
+
+```yaml
+- uses: ./actions/allocate-runner
+  with:
+    broker_url: https://broker.example.com
+    pool: lite
+    required_capabilities: gpu
+```
+
+This requires at least one backend in the selected pool to advertise `gpu`, for example an ARC template or cloud backend dedicated to GPU jobs.
+
+- Region-specific routing:
+
+```yaml
+- uses: ./actions/allocate-runner
+  with:
+    broker_url: https://broker.example.com
+    pool: lite
+    required_capabilities: region:aws-us-east-1
+    excluded_capabilities: cluster-local
+```
+
+If no backend matches the requested capability filters, the broker rejects the allocation request before scheduling.
+
 ## License
 
 Apache-2.0

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -19,6 +19,14 @@ inputs:
     description: Optional comma-separated labels to attach to the allocation request
     required: false
     default: ""
+  required_capabilities:
+    description: Optional comma-separated capability tags that the selected backend must advertise
+    required: false
+    default: ""
+  excluded_capabilities:
+    description: Optional comma-separated capability tags that the selected backend must not advertise
+    required: false
+    default: ""
   oidc_audience:
     description: OIDC audience expected by the broker
     required: false
@@ -53,6 +61,8 @@ runs:
         INPUT_BACKEND: ${{ inputs.backend }}
         INPUT_JOB_TIMEOUT: ${{ inputs.job_timeout }}
         INPUT_LABELS: ${{ inputs.labels }}
+        INPUT_REQUIRED_CAPABILITIES: ${{ inputs.required_capabilities }}
+        INPUT_EXCLUDED_CAPABILITIES: ${{ inputs.excluded_capabilities }}
         INPUT_OIDC_AUDIENCE: ${{ inputs.oidc_audience }}
         INPUT_ALLOW_UNAUTHENTICATED: ${{ inputs.allow_unauthenticated }}
       run: |
@@ -86,6 +96,14 @@ if backend:
 labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
 if labels:
     payload["labels"] = labels
+
+required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
+if required_capabilities:
+    payload["required_capabilities"] = required_capabilities
+
+excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
+if excluded_capabilities:
+    payload["excluded_capabilities"] = excluded_capabilities
 
 print(json.dumps(payload))
 PY

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -63,6 +63,10 @@ config:
           healthy: true
           maxRunners: 4
           weight: 1
+          capabilities:
+            - cluster-local
+            - docker
+            - region:local
           template: arc-full
     - name: lite
       labels:
@@ -80,6 +84,10 @@ config:
           healthy: true
           maxRunners: 2
           weight: 1
+          capabilities:
+            - cluster-local
+            - docker
+            - region:local
           template: arc-lite
         lambda:
           enabled: false
@@ -87,6 +95,8 @@ config:
           maxRunners: 3
           weight: 1
           maxJobDuration: 14m
+          capabilities:
+            - region:aws-us-east-1
           secretRef: uecb-lambda
         cloud-run:
           enabled: false
@@ -94,6 +104,8 @@ config:
           maxRunners: 2
           weight: 1
           maxJobDuration: 30m
+          capabilities:
+            - region:gcp-us-central1
           secretRef: uecb-cloud-run
         azure-functions:
           enabled: false
@@ -101,5 +113,7 @@ config:
           maxRunners: 2
           weight: 1
           maxJobDuration: 25m
+          capabilities:
+            - region:azure-eastus
           secretRef: uecb-azure-functions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,3 +26,15 @@ Within a selected pool, backends use `round-robin` across healthy backends with 
 
 Pools can opt into `weighted-round-robin` instead. Backend weights are configured per pool and only affect selection when that scheduler is enabled.
 
+## Capability Filtering
+
+Capability-aware routing is evaluated before scheduler selection.
+
+- Jobs may send `required_capabilities` and `excluded_capabilities` string arrays on the allocation request.
+- Each backend advertises a normalized capability set through `pools[].backends.<name>.capabilities`.
+- The broker filters the pool down to eligible backends first, then passes only that reduced backend set into the configured scheduler.
+- Pinned backend requests still honor capability filters. If the pinned backend is configured for the pool but excluded by the request, the broker returns a clear rejection instead of falling through to another backend.
+- Missing backend capability metadata means that backend advertises no extra capabilities.
+
+This keeps scheduling policy isolated in the scheduler registry while making capability eligibility deterministic at the API layer.
+

--- a/examples/gitops/kustomize/base/configmap.yaml
+++ b/examples/gitops/kustomize/base/configmap.yaml
@@ -30,6 +30,7 @@ data:
             healthy: true
             maxRunners: 4
             weight: 1
+            capabilities: [cluster-local, docker, region:local]
             template: arc-full
       - name: lite
         labels: [self-hosted, linux, x64, uecb, uecb-lite]
@@ -41,6 +42,7 @@ data:
             healthy: true
             maxRunners: 2
             weight: 1
+            capabilities: [cluster-local, docker, region:local]
             template: arc-lite
           lambda:
             enabled: false
@@ -48,6 +50,7 @@ data:
             maxRunners: 3
             weight: 1
             maxJobDuration: 14m
+            capabilities: [region:aws-us-east-1]
             secretRef: uecb-lambda
           cloud-run:
             enabled: false
@@ -55,6 +58,7 @@ data:
             maxRunners: 2
             weight: 1
             maxJobDuration: 30m
+            capabilities: [region:gcp-us-central1]
             secretRef: uecb-cloud-run
           azure-functions:
             enabled: false
@@ -62,5 +66,6 @@ data:
             maxRunners: 2
             weight: 1
             maxJobDuration: 25m
+            capabilities: [region:azure-eastus]
             secretRef: uecb-azure-functions
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -15,6 +15,7 @@ import (
 )
 
 var ErrUnknownPool = errors.New("pool is not configured")
+var ErrNoMatchingBackendCapabilities = errors.New("no backend matches the requested capabilities")
 
 type Service struct {
 	cfg      model.BrokerConfig
@@ -51,6 +52,10 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	}
 
 	pool, err := s.resolvePool(request.Pool)
+	if err != nil {
+		return model.AllocationStatus{}, err
+	}
+	pool, err = filterEligibleBackends(pool, request)
 	if err != nil {
 		return model.AllocationStatus{}, err
 	}
@@ -102,7 +107,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	}
 
 	allocation.RunnerLabel = provisioned.RunnerLabel
-	allocation.Metadata = provisioned.Metadata
+	allocation.Metadata = backend.WithCapabilitiesMetadata(pool.Backends[selected], provisioned.Metadata)
 	allocation.State = model.StateReady
 	s.store.Save(allocation)
 
@@ -176,6 +181,58 @@ func validateSchedulers(pools []model.PoolConfig, registry *scheduler.Registry) 
 		}
 	}
 	return nil
+}
+
+func filterEligibleBackends(pool model.PoolConfig, request model.AllocationRequest) (model.PoolConfig, error) {
+	required := backend.NormalizeCapabilities(request.RequiredCapabilities)
+	excluded := backend.NormalizeCapabilities(request.ExcludedCapabilities)
+	if len(required) == 0 && len(excluded) == 0 {
+		return pool, nil
+	}
+
+	filtered := pool
+	filtered.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+
+	for name, cfg := range pool.Backends {
+		cfg.Capabilities = backend.NormalizeCapabilities(cfg.Capabilities)
+		if backendMatchesCapabilities(cfg, required, excluded) {
+			filtered.Backends[name] = cfg
+		}
+	}
+
+	if request.Backend != nil {
+		if _, ok := pool.Backends[*request.Backend]; !ok {
+			return model.PoolConfig{}, scheduler.ErrUnknownBackend
+		}
+		if _, ok := filtered.Backends[*request.Backend]; !ok {
+			return model.PoolConfig{}, fmt.Errorf("pinned backend %q does not match the requested capabilities: %w", *request.Backend, ErrNoMatchingBackendCapabilities)
+		}
+		return filtered, nil
+	}
+
+	if len(filtered.Backends) == 0 {
+		return model.PoolConfig{}, fmt.Errorf("%w for pool %q", ErrNoMatchingBackendCapabilities, pool.Name)
+	}
+
+	return filtered, nil
+}
+
+func backendMatchesCapabilities(cfg model.BackendConfig, required, excluded []string) bool {
+	capabilities := backend.CapabilitySet(cfg.Capabilities)
+
+	for _, capability := range required {
+		if _, ok := capabilities[capability]; !ok {
+			return false
+		}
+	}
+
+	for _, capability := range excluded {
+		if _, ok := capabilities[capability]; ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 func newID() string {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,5 +196,123 @@ func TestAllocateFailsWhenHealthCheckFails(t *testing.T) {
 
 	if _, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull}); err != context.DeadlineExceeded {
 		t.Fatalf("expected health check failure, got %v", err)
+	}
+}
+
+func TestAllocateKeepsExistingBehaviorWhenCapabilitiesAreEmpty(t *testing.T) {
+	service := newService()
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:                 model.PoolLite,
+		RequiredCapabilities: []string{"", "  "},
+		ExcludedCapabilities: []string{},
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	if allocation.SelectedBackend != model.BackendARC {
+		t.Fatalf("expected ARC backend, got %s", allocation.SelectedBackend)
+	}
+}
+
+func TestAllocateFiltersBackendsByRequiredCapabilities(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		lambdaCfg := pool.Backends[model.BackendLambda]
+		lambdaCfg.Enabled = true
+		lambdaCfg.Capabilities = []string{"gpu", "region:aws-us-east-1"}
+		pool.Backends[model.BackendLambda] = lambdaCfg
+	})
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:                 model.PoolLite,
+		RequiredCapabilities: []string{"GPU"},
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	if allocation.SelectedBackend != model.BackendLambda {
+		t.Fatalf("expected lambda backend, got %s", allocation.SelectedBackend)
+	}
+
+	if got := allocation.Metadata[backend.MetadataCapabilitiesKey]; got != "gpu,region:aws-us-east-1" {
+		t.Fatalf("unexpected capability metadata: %q", got)
+	}
+}
+
+func TestAllocateFiltersBackendsByExcludedCapabilities(t *testing.T) {
+	service := newService()
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:                 model.PoolLite,
+		ExcludedCapabilities: []string{"cluster-local"},
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	if allocation.SelectedBackend != model.BackendLambda {
+		t.Fatalf("expected lambda backend, got %s", allocation.SelectedBackend)
+	}
+}
+
+func TestAllocateReturnsClearErrorWhenNoBackendMatchesCapabilities(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, cfg := range pool.Backends {
+			cfg.Capabilities = nil
+			pool.Backends[name] = cfg
+		}
+	})
+
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:                 model.PoolLite,
+		RequiredCapabilities: []string{"gpu"},
+	})
+	if !errors.Is(err, ErrNoMatchingBackendCapabilities) {
+		t.Fatalf("expected capability mismatch error, got %v", err)
+	}
+}
+
+func TestAllocateTreatsMissingCapabilityMetadataAsEmptySet(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		lambdaCfg := pool.Backends[model.BackendLambda]
+		lambdaCfg.Enabled = true
+		lambdaCfg.Capabilities = nil
+		pool.Backends[model.BackendLambda] = lambdaCfg
+	})
+
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:                 model.PoolLite,
+		RequiredCapabilities: []string{"region:aws-us-east-1"},
+	})
+	if !errors.Is(err, ErrNoMatchingBackendCapabilities) {
+		t.Fatalf("expected capability mismatch error, got %v", err)
+	}
+}
+
+func TestAllocateRejectsPinnedBackendThatFailsCapabilityFilter(t *testing.T) {
+	service := newService()
+	pinned := model.BackendARC
+
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:                 model.PoolLite,
+		Backend:              &pinned,
+		ExcludedCapabilities: []string{"cluster-local"},
+	})
+	if !errors.Is(err, ErrNoMatchingBackendCapabilities) {
+		t.Fatalf("expected capability mismatch error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "pinned backend") {
+		t.Fatalf("expected pinned backend error context, got %v", err)
 	}
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -3,10 +3,13 @@ package backend
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
+
+const MetadataCapabilitiesKey = "capabilities"
 
 type ProvisionedRunner struct {
 	RunnerLabel string
@@ -38,4 +41,64 @@ func (r *Registry) Get(name model.BackendName) (Backend, bool) {
 func DefaultRunnerLabel(name model.BackendName, allocationID string) string {
 	sanitized := strings.ReplaceAll(string(name), "-", "")
 	return fmt.Sprintf("uecb-%s-%s", sanitized, allocationID)
+}
+
+func NormalizeCapabilities(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		capability := strings.ToLower(strings.TrimSpace(value))
+		if capability == "" {
+			continue
+		}
+		if _, ok := seen[capability]; ok {
+			continue
+		}
+		seen[capability] = struct{}{}
+		normalized = append(normalized, capability)
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	sort.Strings(normalized)
+	return normalized
+}
+
+func CapabilitySet(values []string) map[string]struct{} {
+	normalized := NormalizeCapabilities(values)
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	result := make(map[string]struct{}, len(normalized))
+	for _, value := range normalized {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func WithCapabilitiesMetadata(cfg model.BackendConfig, metadata map[string]string) map[string]string {
+	capabilities := NormalizeCapabilities(cfg.Capabilities)
+	if metadata == nil && len(capabilities) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string, len(metadata)+1)
+	for key, value := range metadata {
+		result[key] = value
+	}
+
+	if len(capabilities) == 0 {
+		delete(result, MetadataCapabilitiesKey)
+		return result
+	}
+
+	result[MetadataCapabilitiesKey] = strings.Join(capabilities, ",")
+	return result
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -36,11 +36,12 @@ func Default() model.BrokerConfig {
 				CapabilityProfile: model.CapabilityFull,
 				Backends: map[model.BackendName]model.BackendConfig{
 					model.BackendARC: {
-						Enabled:    true,
-						Healthy:    true,
-						MaxRunners: 4,
-						Weight:     1,
-						Template:   "arc-full",
+						Enabled:      true,
+						Healthy:      true,
+						MaxRunners:   4,
+						Weight:       1,
+						Capabilities: []string{"cluster-local", "docker", "region:local"},
+						Template:     "arc-full",
 					},
 				},
 			},
@@ -51,11 +52,12 @@ func Default() model.BrokerConfig {
 				CapabilityProfile: model.CapabilityLite,
 				Backends: map[model.BackendName]model.BackendConfig{
 					model.BackendARC: {
-						Enabled:    true,
-						Healthy:    true,
-						MaxRunners: 2,
-						Weight:     1,
-						Template:   "arc-lite",
+						Enabled:      true,
+						Healthy:      true,
+						MaxRunners:   2,
+						Weight:       1,
+						Capabilities: []string{"cluster-local", "docker", "region:local"},
+						Template:     "arc-lite",
 					},
 					model.BackendLambda: {
 						Enabled:        false,
@@ -63,6 +65,7 @@ func Default() model.BrokerConfig {
 						MaxRunners:     3,
 						Weight:         1,
 						MaxJobDuration: 14 * time.Minute,
+						Capabilities:   []string{"region:aws-us-east-1"},
 						SecretRef:      "uecb-lambda",
 					},
 					model.BackendCloudRun: {
@@ -71,6 +74,7 @@ func Default() model.BrokerConfig {
 						MaxRunners:     2,
 						Weight:         1,
 						MaxJobDuration: 30 * time.Minute,
+						Capabilities:   []string{"region:gcp-us-central1"},
 						SecretRef:      "uecb-cloud-run",
 					},
 					model.BackendAzureFunctions: {
@@ -79,6 +83,7 @@ func Default() model.BrokerConfig {
 						MaxRunners:     2,
 						Weight:         1,
 						MaxJobDuration: 25 * time.Minute,
+						Capabilities:   []string{"region:azure-eastus"},
 						SecretRef:      "uecb-azure-functions",
 					},
 				},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -68,6 +68,7 @@ type BackendConfig struct {
 	MaxRunners     int           `yaml:"maxRunners" json:"maxRunners"`
 	Weight         int           `yaml:"weight,omitempty" json:"weight,omitempty"`
 	MaxJobDuration time.Duration `yaml:"maxJobDuration,omitempty" json:"maxJobDuration,omitempty"`
+	Capabilities   []string      `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
 	Template       string        `yaml:"template,omitempty" json:"template,omitempty"`
 	SecretRef      string        `yaml:"secretRef,omitempty" json:"secretRef,omitempty"`
 }
@@ -87,10 +88,12 @@ type BrokerConfig struct {
 }
 
 type AllocationRequest struct {
-	Pool       PoolName      `json:"pool"`
-	Backend    *BackendName  `json:"backend,omitempty"`
-	JobTimeout time.Duration `json:"job_timeout"`
-	Labels     []string      `json:"labels,omitempty"`
+	Pool                 PoolName      `json:"pool"`
+	Backend              *BackendName  `json:"backend,omitempty"`
+	JobTimeout           time.Duration `json:"job_timeout"`
+	Labels               []string      `json:"labels,omitempty"`
+	RequiredCapabilities []string      `json:"required_capabilities,omitempty"`
+	ExcludedCapabilities []string      `json:"excluded_capabilities,omitempty"`
 }
 
 type AllocationStatus struct {


### PR DESCRIPTION
Closes #2

## Summary
- Adds capability-aware backend routing so requests are dispatched based on declared backend capabilities.
- Updates backend initialization and configuration parsing to support capability selection and routing behavior.
- Updates GitOps/docs and action config paths to reflect new routing/values behavior.
- Expands API test coverage around service behavior for capability-aware routing.

## Testing
- `go test ./...`