### PR TITLE
fix: accept string job_timeout and fail stub external backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 `unified-ephemeral-runner-broker` is a public control plane for allocating one-shot GitHub Actions runners across a unified ephemeral capacity pool.
 
-V1 supports exactly four backends:
+V1 models exactly four backends:
 
 - `arc`
 - `lambda`
 - `cloud-run`
 - `azure-functions`
+
+The public repo ships ARC provisioning plus backend-specific external launcher placeholders. External backends should stay disabled until you provide a real launcher integration for the selected platform.
 
 It is intentionally split into two capability pools:
 
@@ -40,9 +42,10 @@ Built-in schedulers:
 
 1. A lightweight workflow step calls `allocate-runner`.
 2. The broker selects an eligible backend from the chosen pool.
-3. The backend provisions an ephemeral runner and returns a unique runner label.
-4. The heavy workflow job runs on that exact label.
-5. The runner executes one job and exits.
+3. The broker sends the request to the selected backend integration; `lambda`, `cloud-run`, and `azure-functions` currently return a clear "not implemented" error when selected without a real launcher integration.
+4. `job_timeout` is accepted as duration strings like `15m`, with numeric nanoseconds still accepted for backward compatibility.
+5. The heavy workflow job runs on that exact label.
+6. The runner executes one job and exits.
 
 ## Project Layout
 
@@ -68,8 +71,8 @@ See [docs/architecture.md](docs/architecture.md) and [docs/security-boundary.md]
 1. Install the Helm chart with external backends disabled.
 2. Create the GitHub auth secret and any enabled backend secrets in the same namespace as the broker.
    The broker validates referenced `secretRef` objects via the Kubernetes API and stays unready until they exist.
-3. Point the `allocate-runner` action at the broker URL.
-4. Start with the `full` pool or ARC-only `lite` pool, then enable external backends one by one.
+3. Point the `allocate-runner` action at the broker URL. The broker accepts `job_timeout` in the same duration-string format used by the action, for example `15m`.
+4. Start with the `full` pool or ARC-only `lite` pool. Only enable an external backend after you have supplied a real launcher integration for that platform.
 
 ## Scheduler Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@
 ## Data Plane
 
 - `arc` provisions in-cluster runners.
-- `lambda`, `cloud-run`, and `azure-functions` provision lite-profile external runners.
+- `lambda`, `cloud-run`, and `azure-functions` are configured here as lite-profile external runners; if no launcher integration exists they return explicit errors instead of reporting a runner as ready.
 - Each runner handles one job and exits.
 
 ## Pools

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -58,8 +57,8 @@ func (s *Server) handleAllocations(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodPost:
-		var request model.AllocationRequest
-		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		request, err := decodeAllocationRequest(r.Body)
+		if err != nil {
 			s.writeError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
+	lambdabackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/lambda"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/config"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func newTestServer(t *testing.T, service *Service) *Server {
+	t.Helper()
+
+	previousRegisterer := prometheus.DefaultRegisterer
+	previousGatherer := prometheus.DefaultGatherer
+	registry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = registry
+	prometheus.DefaultGatherer = registry
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer = previousRegisterer
+		prometheus.DefaultGatherer = previousGatherer
+	})
+
+	return NewServer(service, nil, "", true)
+}
+
+func TestHandleAllocationsAcceptsStringJobTimeout(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+	server := newTestServer(t, service)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	var allocation model.AllocationStatus
+	if err := json.NewDecoder(recorder.Body).Decode(&allocation); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if allocation.SelectedBackend != model.BackendARC {
+		t.Fatalf("expected ARC backend, got %s", allocation.SelectedBackend)
+	}
+
+	wantExpiry := time.Unix(1000, 0).Add(15 * time.Minute)
+	if !allocation.ExpiresAt.Equal(wantExpiry) {
+		t.Fatalf("expected expiry %s, got %s", wantExpiry, allocation.ExpiresAt)
+	}
+}
+
+func TestHandleAllocationsRejectsStubBackend(t *testing.T) {
+	cfg := config.Default()
+	for index := range cfg.Pools {
+		if cfg.Pools[index].Name != model.PoolLite {
+			continue
+		}
+		lambdaCfg := cfg.Pools[index].Backends[model.BackendLambda]
+		lambdaCfg.Enabled = true
+		cfg.Pools[index].Backends[model.BackendLambda] = lambdaCfg
+	}
+
+	service := NewService(
+		cfg,
+		backend.NewRegistry(
+			testBackend{name: model.BackendARC},
+			lambdabackend.New(),
+		),
+		nil,
+	)
+	server := newTestServer(t, service)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"lite","backend":"lambda","job_timeout":"5m"}`))
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	if !strings.Contains(recorder.Body.String(), "not implemented yet") {
+		t.Fatalf("expected not implemented error, got %s", recorder.Body.String())
+	}
+}

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+type durationRequestValue time.Duration
+
+func (d *durationRequestValue) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if raw == "" || raw == "null" {
+		*d = 0
+		return nil
+	}
+
+	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") {
+		var encoded string
+		if err := json.Unmarshal([]byte(raw), &encoded); err != nil {
+			return fmt.Errorf("invalid job_timeout: %w", err)
+		}
+		parsed, err := time.ParseDuration(encoded)
+		if err != nil {
+			return fmt.Errorf("invalid job_timeout: %w", err)
+		}
+		*d = durationRequestValue(parsed)
+		return nil
+	}
+
+	var nanos int64
+	if err := json.Unmarshal([]byte(raw), &nanos); err != nil {
+		return fmt.Errorf("invalid job_timeout: expected duration string (for example \"15m\") or nanosecond integer")
+	}
+	*d = durationRequestValue(time.Duration(nanos))
+	return nil
+}
+
+func decodeAllocationRequest(reader io.Reader) (model.AllocationRequest, error) {
+	var request struct {
+		Pool       model.PoolName       `json:"pool"`
+		Backend    *model.BackendName   `json:"backend,omitempty"`
+		JobTimeout durationRequestValue `json:"job_timeout"`
+		Labels     []string             `json:"labels,omitempty"`
+	}
+
+	decoder := json.NewDecoder(reader)
+	if err := decoder.Decode(&request); err != nil {
+		return model.AllocationRequest{}, fmt.Errorf("invalid allocation request: %w", err)
+	}
+
+	var backend *model.BackendName
+	if request.Backend != nil {
+		backendCopy := *request.Backend
+		backend = &backendCopy
+	}
+
+	return model.AllocationRequest{
+		Pool:       request.Pool,
+		Backend:    backend,
+		JobTimeout: time.Duration(request.JobTimeout),
+		Labels:     append([]string(nil), request.Labels...),
+	}, nil
+}

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+func TestDecodeAllocationRequestAcceptsDurationString(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","job_timeout":"15m"}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.JobTimeout != 15*time.Minute {
+		t.Fatalf("expected 15m timeout, got %s", request.JobTimeout)
+	}
+}
+
+func TestDecodeAllocationRequestAcceptsDurationNumber(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","job_timeout":900000000000}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.JobTimeout != 15*time.Minute {
+		t.Fatalf("expected 900000000000 nanoseconds, got %s", request.JobTimeout)
+	}
+}
+
+func TestDecodeAllocationRequestRejectsInvalidDuration(t *testing.T) {
+	_, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","job_timeout": "nonsense"}`)))
+	if err == nil {
+		t.Fatal("expected invalid job_timeout to fail")
+	}
+}
+
+func TestDecodeAllocationRequestParsesBackendAsString(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","backend":"lambda","job_timeout":"1m"}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.Backend == nil || *request.Backend != model.BackendLambda {
+		t.Fatalf("expected backend lambda, got %#v", request.Backend)
+	}
+}
+
+func TestDecodeAllocationRequestCopiesLabels(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","labels":["a","b","c"]}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(request.Labels) != 3 || request.Labels[0] != "a" || request.Labels[2] != "c" {
+		t.Fatalf("unexpected labels: %#v", request.Labels)
+	}
+}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
-	arcbackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/arc"
 	azurebackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/azurefunctions"
 	cloudbackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/cloudrun"
 	lambdabackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/lambda"
@@ -14,6 +15,24 @@ import (
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/scheduler"
 )
+
+type testBackend struct {
+	name model.BackendName
+}
+
+func (b testBackend) Name() model.BackendName {
+	return b.name
+}
+
+func (b testBackend) Provision(_ context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	return backend.ProvisionedRunner{
+		RunnerLabel: backend.DefaultRunnerLabel(b.name, allocation.ID),
+		Metadata: map[string]string{
+			"pool":        string(request.Pool),
+			"provisioner": fmt.Sprintf("test-%s", b.name),
+		},
+	}, nil
+}
 
 func newService() *Service {
 	return newServiceWithConfig(func(pool *model.PoolConfig) {
@@ -37,10 +56,10 @@ func newServiceWithConfig(mutator func(*model.PoolConfig)) *Service {
 	return NewService(
 		cfg,
 		backend.NewRegistry(
-			arcbackend.New(),
-			lambdabackend.New(),
-			cloudbackend.New(),
-			azurebackend.New(),
+			testBackend{name: model.BackendARC},
+			testBackend{name: model.BackendLambda},
+			testBackend{name: model.BackendCloudRun},
+			testBackend{name: model.BackendAzureFunctions},
 		),
 		nil,
 	)
@@ -132,9 +151,57 @@ func TestAllocateRespectsPinnedBackendTimeoutLimit(t *testing.T) {
 	}
 }
 
+func TestAllocateFailsWithStubbedExternalBackend(t *testing.T) {
+	cfg := config.Default()
+	for index := range cfg.Pools {
+		if cfg.Pools[index].Name != model.PoolLite {
+			continue
+		}
+		lambdaCfg := cfg.Pools[index].Backends[model.BackendLambda]
+		lambdaCfg.Enabled = true
+		cfg.Pools[index].Backends[model.BackendLambda] = lambdaCfg
+		cloudCfg := cfg.Pools[index].Backends[model.BackendCloudRun]
+		cloudCfg.Enabled = true
+		cfg.Pools[index].Backends[model.BackendCloudRun] = cloudCfg
+		azureCfg := cfg.Pools[index].Backends[model.BackendAzureFunctions]
+		azureCfg.Enabled = true
+		cfg.Pools[index].Backends[model.BackendAzureFunctions] = azureCfg
+	}
+
+	service := NewService(
+		cfg,
+		backend.NewRegistry(
+			testBackend{name: model.BackendARC},
+			lambdabackend.New(),
+			cloudbackend.New(),
+			azurebackend.New(),
+		),
+		nil,
+	)
+
+	for _, backend := range []model.BackendName{
+		model.BackendLambda,
+		model.BackendCloudRun,
+		model.BackendAzureFunctions,
+	} {
+		backend := backend
+		_, err := service.Allocate(context.Background(), model.AllocationRequest{
+			Pool:       model.PoolLite,
+			Backend:    &backend,
+			JobTimeout: 5 * time.Minute,
+		})
+		if err == nil {
+			t.Fatalf("expected %s allocation to fail", backend)
+		}
+		if !strings.Contains(err.Error(), "not implemented yet") {
+			t.Fatalf("expected not implemented error for %s, got %v", backend, err)
+		}
+	}
+}
+
 func TestCancelReleasesCapacity(t *testing.T) {
 	service := newService()
-	backend := model.BackendLambda
+	backend := model.BackendARC
 
 	first, err := service.Allocate(context.Background(), model.AllocationRequest{
 		Pool:       model.PoolLite,
@@ -188,7 +255,7 @@ func TestSweepExpiredMarksReadyAllocationsExpired(t *testing.T) {
 func TestAllocateFailsWhenHealthCheckFails(t *testing.T) {
 	service := NewService(
 		config.Default(),
-		backend.NewRegistry(arcbackend.New()),
+		backend.NewRegistry(testBackend{name: model.BackendARC}),
 		func(context.Context) error { return context.DeadlineExceeded },
 	)
 

--- a/internal/backend/azurefunctions/backend.go
+++ b/internal/backend/azurefunctions/backend.go
@@ -2,6 +2,7 @@ package azurefunctions
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
@@ -17,15 +18,6 @@ func (b *Backend) Name() model.BackendName {
 	return model.BackendAzureFunctions
 }
 
-func (b *Backend) Provision(_ context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
-	return backend.ProvisionedRunner{
-		RunnerLabel: backend.DefaultRunnerLabel(model.BackendAzureFunctions, allocation.ID),
-		Metadata: map[string]string{
-			"pool":            string(request.Pool),
-			"capability":      "lite",
-			"provisioner":     "azure-functions-container",
-			"lifecycle":       "ephemeral",
-			"supports_docker": "false",
-		},
-	}, nil
+func (b *Backend) Provision(_ context.Context, _ model.AllocationRequest, _ model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	return backend.ProvisionedRunner{}, fmt.Errorf("azure-functions backend is not implemented yet")
 }

--- a/internal/backend/cloudrun/backend.go
+++ b/internal/backend/cloudrun/backend.go
@@ -2,6 +2,7 @@ package cloudrun
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
@@ -17,15 +18,6 @@ func (b *Backend) Name() model.BackendName {
 	return model.BackendCloudRun
 }
 
-func (b *Backend) Provision(_ context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
-	return backend.ProvisionedRunner{
-		RunnerLabel: backend.DefaultRunnerLabel(model.BackendCloudRun, allocation.ID),
-		Metadata: map[string]string{
-			"pool":            string(request.Pool),
-			"capability":      "lite",
-			"provisioner":     "cloud-run-job",
-			"lifecycle":       "ephemeral",
-			"supports_docker": "false",
-		},
-	}, nil
+func (b *Backend) Provision(_ context.Context, _ model.AllocationRequest, _ model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	return backend.ProvisionedRunner{}, fmt.Errorf("cloud-run backend is not implemented yet")
 }

--- a/internal/backend/lambda/backend.go
+++ b/internal/backend/lambda/backend.go
@@ -2,6 +2,7 @@ package lambda
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
@@ -17,15 +18,6 @@ func (b *Backend) Name() model.BackendName {
 	return model.BackendLambda
 }
 
-func (b *Backend) Provision(_ context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
-	return backend.ProvisionedRunner{
-		RunnerLabel: backend.DefaultRunnerLabel(model.BackendLambda, allocation.ID),
-		Metadata: map[string]string{
-			"pool":            string(request.Pool),
-			"capability":      "lite",
-			"provisioner":     "lambda-container",
-			"lifecycle":       "ephemeral",
-			"supports_docker": "false",
-		},
-	}, nil
+func (b *Backend) Provision(_ context.Context, _ model.AllocationRequest, _ model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	return backend.ProvisionedRunner{}, fmt.Errorf("lambda backend is not implemented yet")
 }


### PR DESCRIPTION
## Summary
- accept allocation job_timeout in the string duration format sent by ctions/allocate-runner
- keep numeric nanosecond duration compatibility in the HTTP API
- make lambda, cloud-run, and zure-functions fail clearly instead of returning fake ready allocations
- document that external backends in the public repo are placeholders until a real launcher integration exists

## Validation
- go test ./...
- go test ./internal/api -run 'TestDecodeAllocationRequestAcceptsDurationString|TestHandleAllocationsRejectsStubBackend'
- git diff --check

## Context
This came from the live home-repo canary: the action-compatible timeout format was rejected by the broker API, and enabling a stub external backend could return a fake successful allocation.