### PR TITLE
Add Azure Functions lite backend launcher

### DIFF
--- a/Dockerfile.azure-functions
+++ b/Dockerfile.azure-functions
@@ -1,0 +1,34 @@
+FROM mcr.microsoft.com/azure-functions/python:4-python3.11
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN set -eux; \
+  apt-get update; \
+  libicu_pkg="$(apt-cache search '^libicu[0-9]+$' | awk '{print $1}' | sort -V | tail -n 1)"; \
+  if [ -z "${libicu_pkg}" ]; then echo "unable to resolve libicu package" >&2; exit 1; fi; \
+  apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    gzip \
+    jq \
+    tar \
+    unzip \
+    "${libicu_pkg}"; \
+  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/site/wwwroot
+
+COPY docker/launcher/entrypoint.sh /opt/uecb/runner-entrypoint.sh
+RUN chmod +x /opt/uecb/runner-entrypoint.sh
+
+COPY docker/azure-functions/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+  && rm -f /tmp/requirements.txt
+
+COPY docker/azure-functions/host.json /home/site/wwwroot/host.json
+COPY docker/azure-functions/function_app.py /home/site/wwwroot/function_app.py

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ V1 models exactly five backends:
 - `cloud-run`
 - `azure-functions`
 
-The public repo ships ARC provisioning plus generic secret-backed external launcher dispatch for `codebuild`, `lambda`, and `cloud-run`. Each enabled external backend must point at a real launcher controller through a Kubernetes secret in the broker namespace.
+The public repo ships ARC provisioning plus generic secret-backed external launcher dispatch for `codebuild`, `lambda`, `cloud-run`, and `azure-functions`. Each enabled external backend must point at a real launcher controller through a Kubernetes secret in the broker namespace.
 
 It is intentionally split into two capability pools:
 
@@ -43,7 +43,7 @@ Built-in schedulers:
 
 1. A lightweight workflow step calls `allocate-runner`.
 2. The broker selects an eligible backend from the chosen pool.
-3. The broker sends the request to the selected backend integration. `codebuild`, `lambda`, and `cloud-run` dispatch through a secret-backed HTTP controller contract; `azure-functions` remains a placeholder until a real launcher integration is supplied.
+3. The broker sends the request to the selected backend integration. `codebuild`, `lambda`, `cloud-run`, and `azure-functions` dispatch through a secret-backed HTTP controller contract.
 4. `job_timeout` is accepted as duration strings like `15m`, with numeric nanoseconds still accepted for backward compatibility.
 5. The heavy workflow job runs on that exact label.
 6. The runner executes one job and exits.
@@ -52,6 +52,7 @@ Built-in schedulers:
 
 - `cmd/broker`: broker entrypoint
 - `internal/`: broker, scheduler, backend, GitHub, and config packages
+- `docker/azure-functions`: published Azure Functions controller and runner container
 - `charts/unified-ephemeral-runner-broker`: Helm chart
 - `actions/allocate-runner`: public workflow integration surface
 - `examples/`: generic Terraform and GitOps consumption examples
@@ -77,6 +78,14 @@ See [docs/architecture.md](docs/architecture.md) and [docs/security-boundary.md]
    `dispatch_token`: optional bearer token sent to that endpoint.
 3. Point the `allocate-runner` action at the broker URL. The broker accepts `job_timeout` in the same duration-string format used by the action, for example `15m`.
 4. Start with the `full` pool or ARC-only `lite` pool. Only enable an external backend after you have supplied a real launcher integration for that platform and the matching `secretRef`.
+
+## Azure Functions Launcher
+
+The published Azure Functions launcher image lives in `docker/azure-functions` and is designed for a Linux custom-container Function App.
+
+- The HTTP dispatch endpoint returns quickly and enqueues the allocation.
+- A queue-triggered function execution runs the ephemeral GitHub runner inside the same Function App container.
+- Use a hosting plan that supports long-running non-HTTP executions, such as Premium or Dedicated with `alwaysOn` enabled. The HTTP request still needs to finish quickly even when the runner job itself can run longer.
 
 ## GitHub Scope
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -33,7 +33,7 @@ func main() {
 		codebuildbackend.New(cfg, secretReader),
 		lambdabackend.New(cfg, secretReader),
 		cloudbackend.New(cfg, secretReader),
-		azurebackend.New(),
+		azurebackend.New(cfg, secretReader),
 	)
 	healthChecker, err := runtime.NewSecretRefCheckerFromEnv(cfg)
 	if err != nil {

--- a/docker/azure-functions/function_app.py
+++ b/docker/azure-functions/function_app.py
@@ -1,0 +1,300 @@
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import traceback
+import urllib.parse
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import azure.functions as func
+from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+from azure.storage.blob import BlobServiceClient
+from azure.storage.queue import QueueClient
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+BACKEND_NAME = "azure-functions"
+DEFAULT_DISPATCH_QUEUE = "uecb-azure-functions-dispatch"
+DEFAULT_STATUS_CONTAINER = "uecb-azure-functions-status"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def env(name: str, default: str = "") -> str:
+    return str(os.environ.get(name) or default)
+
+
+def storage_connection_string() -> str:
+    value = env("AzureWebJobsStorage")
+    if not value:
+        raise RuntimeError("AzureWebJobsStorage is required")
+    return value
+
+
+def dispatch_token() -> str:
+    return env("UECB_DISPATCH_TOKEN")
+
+
+def dispatch_queue_name() -> str:
+    return DEFAULT_DISPATCH_QUEUE
+
+
+def status_container_name() -> str:
+    return env("UECB_STATUS_CONTAINER", DEFAULT_STATUS_CONTAINER)
+
+
+def status_container_client():
+    client = BlobServiceClient.from_connection_string(storage_connection_string()).get_container_client(
+        status_container_name()
+    )
+    try:
+        client.create_container()
+    except ResourceExistsError:
+        pass
+    return client
+
+
+def queue_client() -> QueueClient:
+    client = QueueClient.from_connection_string(
+        storage_connection_string(),
+        dispatch_queue_name(),
+    )
+    try:
+        client.create_queue()
+    except ResourceExistsError:
+        pass
+    return client
+
+
+def resource_details_url() -> str:
+    subscription_id = env("UECB_AZURE_SUBSCRIPTION_ID")
+    resource_group = env("UECB_AZURE_RESOURCE_GROUP")
+    app_name = env("WEBSITE_SITE_NAME") or env("UECB_AZURE_FUNCTION_APP_NAME")
+    if not subscription_id or not resource_group or not app_name:
+        return ""
+    resource_path = (
+        f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+        f"/providers/Microsoft.Web/sites/{app_name}"
+    )
+    return f"https://portal.azure.com/#resource{resource_path}/overview"
+
+
+def request_action(req: func.HttpRequest, payload: dict[str, Any]) -> str:
+    return str(req.params.get("action") or payload.get("action") or "").strip().lower()
+
+
+def authorized(req: func.HttpRequest) -> bool:
+    expected = dispatch_token().strip()
+    if not expected:
+        return True
+    return req.headers.get("Authorization", "") == f"Bearer {expected}"
+
+
+def json_response(payload: dict[str, Any], status_code: int = 200) -> func.HttpResponse:
+    return func.HttpResponse(
+        body=json.dumps(payload),
+        status_code=status_code,
+        mimetype="application/json",
+    )
+
+
+def read_status(execution_id: str) -> dict[str, Any] | None:
+    blob_client = status_container_client().get_blob_client(f"{execution_id}.json")
+    try:
+        return json.loads(blob_client.download_blob().readall())
+    except ResourceNotFoundError:
+        return None
+
+
+def write_status(execution_id: str, **changes: Any) -> dict[str, Any]:
+    status = read_status(execution_id) or {"execution_id": execution_id}
+    status.update(changes)
+    status["execution_id"] = execution_id
+    status["updated_at"] = utc_now()
+    if "details_url" not in status:
+        status["details_url"] = resource_details_url()
+
+    blob_client = status_container_client().get_blob_client(f"{execution_id}.json")
+    blob_client.upload_blob(json.dumps(status), overwrite=True)
+    return status
+
+
+def status_url_for(req: func.HttpRequest, execution_id: str) -> str:
+    base_url = req.url.split("?", 1)[0]
+    return f"{base_url}?action=status&execution_id={urllib.parse.quote(execution_id, safe='')}"
+
+
+def normalize_dispatch(payload: dict[str, Any]) -> dict[str, Any]:
+    execution_id = f"azf-{uuid.uuid4().hex[:24]}"
+    runner_label = str(payload.get("runner_label") or "").strip() or f"uecb-azure-functions-{execution_id}"
+    runner_name = str(payload.get("runner_name") or "").strip() or runner_label
+    github = payload.get("github") or {}
+    normalized = dict(payload)
+    normalized["backend"] = BACKEND_NAME
+    normalized["execution_id"] = execution_id
+    normalized["runner_label"] = runner_label
+    normalized["runner_name"] = runner_name
+    normalized["details_url"] = resource_details_url()
+    normalized["github"] = {
+        "scope_type": str(github.get("scope_type") or "").strip(),
+        "organization": str(github.get("organization") or "").strip(),
+        "owner": str(github.get("owner") or "").strip(),
+        "repository": str(github.get("repository") or "").strip(),
+        "target_url": str(github.get("target_url") or "").strip(),
+        "runner_group": str(github.get("runner_group") or "").strip(),
+    }
+    normalized["runner_labels"] = [str(value).strip() for value in normalized.get("runner_labels") or [] if str(value).strip()]
+    normalized["requested_labels"] = [
+        str(value).strip() for value in normalized.get("requested_labels") or [] if str(value).strip()
+    ]
+    return normalized
+
+
+def build_runner_environment(payload: dict[str, Any], work_root: str) -> dict[str, str]:
+    github = payload.get("github") or {}
+    github_pat = env("UECB_GITHUB_PAT")
+    if not github_pat:
+        raise RuntimeError("UECB_GITHUB_PAT is required")
+    if not github.get("scope_type"):
+        raise RuntimeError("dispatch payload is missing github.scope_type")
+    if not github.get("target_url"):
+        raise RuntimeError("dispatch payload is missing github.target_url")
+
+    return {
+        "GITHUB_PAT": github_pat,
+        "GITHUB_SCOPE_TYPE": str(github.get("scope_type") or ""),
+        "GITHUB_ORGANIZATION": str(github.get("organization") or ""),
+        "GITHUB_OWNER": str(github.get("owner") or ""),
+        "GITHUB_REPOSITORY": str(github.get("repository") or ""),
+        "GITHUB_TARGET_URL": str(github.get("target_url") or ""),
+        "RUNNER_GROUP": str(github.get("runner_group") or ""),
+        "RUNNER_NAME": str(payload.get("runner_name") or payload.get("runner_label") or payload.get("execution_id") or ""),
+        "RUNNER_LABELS": ",".join(payload.get("runner_labels") or []),
+        "RUNNER_ROOT": os.path.join(work_root, "runner"),
+        "RUNNER_VERSION": env("UECB_RUNNER_VERSION", "2.333.1"),
+    }
+
+
+@app.route(route="dispatch", methods=["GET", "POST"], auth_level=func.AuthLevel.ANONYMOUS)
+def dispatch(req: func.HttpRequest) -> func.HttpResponse:
+    if not authorized(req):
+        return json_response({"ok": False, "error": "unauthorized"}, status_code=401)
+
+    try:
+        payload = req.get_json()
+    except ValueError:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    action = request_action(req, payload)
+
+    if action == "verify":
+        queue_client().get_queue_properties()
+        status_container_client().get_container_properties()
+        return json_response({"ok": True, "backend": BACKEND_NAME})
+
+    if action == "status":
+        execution_id = str(payload.get("execution_id") or req.params.get("execution_id") or "").strip()
+        if not execution_id:
+            return json_response({"ok": False, "error": "missing execution_id"}, status_code=400)
+        status = read_status(execution_id)
+        if status is None:
+            return json_response({"ok": False, "error": "execution not found", "execution_id": execution_id}, status_code=404)
+        return json_response(status)
+
+    if action != "dispatch":
+        return json_response({"ok": False, "error": "unsupported action"}, status_code=400)
+
+    normalized = normalize_dispatch(payload)
+    execution_id = normalized["execution_id"]
+    queue_client().send_message(json.dumps(normalized))
+    write_status(
+        execution_id,
+        ok=True,
+        state="accepted",
+        backend=BACKEND_NAME,
+        runner_label=normalized["runner_label"],
+        details_url=normalized["details_url"],
+        accepted_at=utc_now(),
+    )
+
+    return json_response(
+        {
+            "ok": True,
+            "execution_id": execution_id,
+            "runner_label": normalized["runner_label"],
+            "status_url": status_url_for(req, execution_id),
+            "details_url": normalized["details_url"],
+            "metadata": {
+                "provider": BACKEND_NAME,
+                "queue_name": dispatch_queue_name(),
+            },
+        },
+        status_code=202,
+    )
+
+
+@app.queue_trigger(arg_name="msg", queue_name=DEFAULT_DISPATCH_QUEUE, connection="AzureWebJobsStorage")
+def run_runner(msg: func.QueueMessage) -> None:
+    payload = json.loads(msg.get_body().decode("utf-8"))
+    execution_id = str(payload.get("execution_id") or "").strip()
+    if not execution_id:
+        logging.error("queue payload missing execution_id")
+        return
+
+    work_root = tempfile.mkdtemp(prefix=f"uecb-azure-functions-{execution_id}-")
+    write_status(
+        execution_id,
+        ok=True,
+        state="running",
+        backend=BACKEND_NAME,
+        runner_label=payload.get("runner_label", ""),
+        details_url=payload.get("details_url", ""),
+        started_at=utc_now(),
+    )
+
+    try:
+        runner_env = os.environ.copy()
+        runner_env.update(build_runner_environment(payload, work_root))
+        completed = subprocess.run(
+            ["/opt/uecb/runner-entrypoint.sh"],
+            check=False,
+            env=runner_env,
+        )
+        if completed.returncode == 0:
+            write_status(
+                execution_id,
+                ok=True,
+                state="completed",
+                exit_code=completed.returncode,
+                completed_at=utc_now(),
+            )
+            return
+
+        write_status(
+            execution_id,
+            ok=False,
+            state="failed",
+            exit_code=completed.returncode,
+            completed_at=utc_now(),
+            last_error=f"runner exited with code {completed.returncode}",
+        )
+    except Exception as exc:
+        logging.exception("azure functions runner execution failed")
+        write_status(
+            execution_id,
+            ok=False,
+            state="failed",
+            completed_at=utc_now(),
+            last_error=str(exc),
+            traceback=traceback.format_exc(limit=20),
+        )
+    finally:
+        shutil.rmtree(work_root, ignore_errors=True)

--- a/docker/azure-functions/host.json
+++ b/docker/azure-functions/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "functionTimeout": "01:00:00",
+  "extensions": {
+    "queues": {
+      "batchSize": 1,
+      "newBatchThreshold": 0,
+      "maxDequeueCount": 1,
+      "visibilityTimeout": "00:45:00"
+    }
+  }
+}

--- a/docker/azure-functions/requirements.txt
+++ b/docker/azure-functions/requirements.txt
@@ -1,0 +1,3 @@
+azure-functions>=1.21,<2.0
+azure-storage-blob>=12.19,<13.0
+azure-storage-queue>=12.9,<13.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,8 +13,8 @@
 ## Data Plane
 
 - `arc` provisions in-cluster runners.
-- `codebuild`, `lambda`, and `cloud-run` are lite-profile external runners that dispatch into provider-owned launcher controllers.
-- `azure-functions` remains a placeholder backend until a real launcher integration is supplied.
+- `codebuild`, `lambda`, `cloud-run`, and `azure-functions` are lite-profile external runners that dispatch into provider-owned launcher controllers using the shared external dispatch contract.
+- The public Azure Functions launcher uses an HTTP dispatch endpoint only for admission and status. Actual runner execution happens on a queue-triggered function inside the same container so the HTTP trigger does not have to stay open for the whole job.
 - Each runner handles one job and exits.
 
 ## Pools

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -8,6 +8,5 @@ variable "functions_image" {
 }
 
 output "next_step" {
-  value = "Create the Azure Functions lite launcher resources, wire a backend secret ref, and point the broker config at the published launcher image."
+  value = "Create a Linux custom-container Function App on a Premium or Dedicated plan, point it at the published azure-functions image, wire the backend secret ref, and enable the azure-functions backend in broker config."
 }
-

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -229,7 +229,7 @@ func TestAllocateFailsWhenExternalBackendSecretIsMissing(t *testing.T) {
 			codebuildbackend.New(cfg, missingSecretReader{}),
 			lambdabackend.New(cfg, missingSecretReader{}),
 			cloudbackend.New(cfg, missingSecretReader{}),
-			azurebackend.New(),
+			azurebackend.New(cfg, missingSecretReader{}),
 		),
 		nil,
 	)
@@ -248,12 +248,6 @@ func TestAllocateFailsWhenExternalBackendSecretIsMissing(t *testing.T) {
 		})
 		if err == nil {
 			t.Fatalf("expected %s allocation to fail", backend)
-		}
-		if backend == model.BackendAzureFunctions {
-			if !strings.Contains(err.Error(), "not implemented yet") {
-				t.Fatalf("expected stub error for %s, got %v", backend, err)
-			}
-			continue
 		}
 		if !strings.Contains(err.Error(), "secret not found") {
 			t.Fatalf("expected secret error for %s, got %v", backend, err)

--- a/internal/backend/azurefunctions/backend.go
+++ b/internal/backend/azurefunctions/backend.go
@@ -1,23 +1,13 @@
 package azurefunctions
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/externaldispatch"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/runtime"
 )
 
-type Backend struct{}
+type Backend = externaldispatch.Backend
 
-func New() *Backend {
-	return &Backend{}
-}
-
-func (b *Backend) Name() model.BackendName {
-	return model.BackendAzureFunctions
-}
-
-func (b *Backend) Provision(_ context.Context, _ model.AllocationRequest, _ model.AllocationStatus) (backend.ProvisionedRunner, error) {
-	return backend.ProvisionedRunner{}, fmt.Errorf("azure-functions backend is not implemented yet")
+func New(cfg model.BrokerConfig, secrets runtime.SecretReader) *Backend {
+	return externaldispatch.New(model.BackendAzureFunctions, cfg, secrets)
 }

--- a/internal/backend/azurefunctions/backend_test.go
+++ b/internal/backend/azurefunctions/backend_test.go
@@ -1,0 +1,84 @@
+package azurefunctions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/config"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+type staticSecrets map[string]map[string]string
+
+func (s staticSecrets) ReadSecret(_ context.Context, name string) (map[string]string, error) {
+	values, ok := s[name]
+	if !ok {
+		return nil, context.DeadlineExceeded
+	}
+	copyValues := make(map[string]string, len(values))
+	for key, value := range values {
+		copyValues[key] = value
+	}
+	return copyValues, nil
+}
+
+func TestProvisionDispatchesToAzureFunctions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer broker-secret" {
+			t.Fatalf("expected authorization header, got %q", got)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload["backend"] != string(model.BackendAzureFunctions) {
+			t.Fatalf("expected backend %q, got %v", model.BackendAzureFunctions, payload["backend"])
+		}
+
+		_, _ = w.Write([]byte(`{"execution_id":"run-azf-123","metadata":{"platform":"azure-functions"}}`))
+	}))
+	defer server.Close()
+
+	cfg := config.Default()
+	poolIndex := 1
+	azureCfg := cfg.Pools[poolIndex].Backends[model.BackendAzureFunctions]
+	azureCfg.Enabled = true
+	azureCfg.SecretRef = "uecb-azure-functions"
+	cfg.Pools[poolIndex].Backends[model.BackendAzureFunctions] = azureCfg
+
+	backend := New(cfg, staticSecrets{
+		"uecb-azure-functions": {
+			"dispatch_url":   server.URL,
+			"dispatch_token": "broker-secret",
+		},
+	})
+
+	provisioned, err := backend.Provision(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 10 * time.Minute,
+	}, model.AllocationStatus{
+		ID:   "azf-001",
+		Pool: model.PoolLite,
+	})
+	if err != nil {
+		t.Fatalf("provision failed: %v", err)
+	}
+	if provisioned.RunnerLabel != "uecb-azurefunctions-azf-001" {
+		t.Fatalf("unexpected runner label %q", provisioned.RunnerLabel)
+	}
+	if provisioned.Metadata["execution_id"] != "run-azf-123" {
+		t.Fatalf("expected execution_id metadata, got %+v", provisioned.Metadata)
+	}
+	if provisioned.Metadata["platform"] != "azure-functions" {
+		t.Fatalf("expected platform metadata, got %v", provisioned.Metadata["platform"])
+	}
+	if !strings.Contains(provisioned.Metadata["dispatch_url"], "http://") {
+		t.Fatalf("expected dispatch_url metadata, got %q", provisioned.Metadata["dispatch_url"])
+	}
+}


### PR DESCRIPTION
Closes #14

## Summary
- replace the broker-side `azure-functions` stub with the shared external-dispatch adapter
- add a published Azure Functions custom-container launcher that accepts HTTP dispatch, enqueues work, and runs the GitHub runner from a queue-triggered function
- update docs and the generic Azure example so downstream repos consume the published image instead of carrying bespoke launcher logic

## Validation
- `go test ./...`
- `python -m py_compile docker/azure-functions/function_app.py`
- `docker build -f Dockerfile.azure-functions -t uecb-azure-functions:test .`
