### PR TITLE
fix: add Azure Functions extension bundle

### DIFF
--- a/docker/azure-functions/host.json
+++ b/docker/azure-functions/host.json
@@ -1,6 +1,10 @@
 {
   "version": "2.0",
   "functionTimeout": "01:00:00",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
   "extensions": {
     "queues": {
       "batchSize": 1,


### PR DESCRIPTION
## Summary
- add the v4 extension bundle to the Azure Functions host config
- ensure the queue trigger used by the Azure Functions launcher can index in the published image

## Testing
- go test ./...
- python -m py_compile docker/azure-functions/function_app.py
- docker build -f Dockerfile.azure-functions -t uecb-azure-functions:hostfix .

Refs #14