### PR TITLE
Extend Azure Functions dispatch timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See [docs/architecture.md](docs/architecture.md) and [docs/security-boundary.md]
 The published Azure Functions launcher image lives in `docker/azure-functions` and is designed for a Linux custom-container Function App.
 
 - The HTTP dispatch endpoint returns quickly and enqueues the allocation.
+- The broker waits up to 90 seconds for the Azure Functions dispatch controller so a cold-started Function App can return its admission response.
 - A queue-triggered function execution runs the ephemeral GitHub runner inside the same Function App container.
 - Use a hosting plan that supports long-running non-HTTP executions, such as Premium or Dedicated with `alwaysOn` enabled. The HTTP request still needs to finish quickly even when the runner job itself can run longer.
 

--- a/internal/backend/externaldispatch/backend.go
+++ b/internal/backend/externaldispatch/backend.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
-	secretKeyDispatchURL   = "dispatch_url"
-	secretKeyDispatchToken = "dispatch_token"
+	secretKeyDispatchURL          = "dispatch_url"
+	secretKeyDispatchToken        = "dispatch_token"
+	defaultDispatchTimeout        = 20 * time.Second
+	azureFunctionsDispatchTimeout = 90 * time.Second
 )
 
 type HTTPClient interface {
@@ -32,17 +34,17 @@ type Backend struct {
 }
 
 type dispatchRequest struct {
-	Action        string          `json:"action"`
-	Backend       string          `json:"backend"`
-	AllocationID  string          `json:"allocation_id"`
-	Pool          string          `json:"pool"`
-	RunnerLabel   string          `json:"runner_label"`
-	RunnerName    string          `json:"runner_name"`
-	RunnerLabels  []string        `json:"runner_labels"`
-	RequestedLabels []string      `json:"requested_labels,omitempty"`
-	JobTimeout    string          `json:"job_timeout"`
-	JobTimeoutSeconds int64       `json:"job_timeout_seconds"`
-	GitHub        dispatchGitHub  `json:"github"`
+	Action            string         `json:"action"`
+	Backend           string         `json:"backend"`
+	AllocationID      string         `json:"allocation_id"`
+	Pool              string         `json:"pool"`
+	RunnerLabel       string         `json:"runner_label"`
+	RunnerName        string         `json:"runner_name"`
+	RunnerLabels      []string       `json:"runner_labels"`
+	RequestedLabels   []string       `json:"requested_labels,omitempty"`
+	JobTimeout        string         `json:"job_timeout"`
+	JobTimeoutSeconds int64          `json:"job_timeout_seconds"`
+	GitHub            dispatchGitHub `json:"github"`
 }
 
 type dispatchGitHub struct {
@@ -68,8 +70,17 @@ func New(name model.BackendName, cfg model.BrokerConfig, secrets runtime.SecretR
 		cfg:     cfg,
 		secrets: secrets,
 		client: &http.Client{
-			Timeout: 20 * time.Second,
+			Timeout: dispatchTimeout(name),
 		},
+	}
+}
+
+func dispatchTimeout(name model.BackendName) time.Duration {
+	switch name {
+	case model.BackendAzureFunctions:
+		return azureFunctionsDispatchTimeout
+	default:
+		return defaultDispatchTimeout
 	}
 }
 
@@ -110,15 +121,15 @@ func (b *Backend) Provision(ctx context.Context, request model.AllocationRequest
 
 	runnerLabel := backend.DefaultRunnerLabel(b.name, allocation.ID)
 	payload := dispatchRequest{
-		Action:          "dispatch",
-		Backend:         string(b.name),
-		AllocationID:    allocation.ID,
-		Pool:            string(pool.Name),
-		RunnerLabel:     runnerLabel,
-		RunnerName:      runnerLabel,
-		RunnerLabels:    combineLabels(pool.Labels, allocation.RequestedLabels, runnerLabel),
-		RequestedLabels: append([]string(nil), allocation.RequestedLabels...),
-		JobTimeout:      request.JobTimeout.String(),
+		Action:            "dispatch",
+		Backend:           string(b.name),
+		AllocationID:      allocation.ID,
+		Pool:              string(pool.Name),
+		RunnerLabel:       runnerLabel,
+		RunnerName:        runnerLabel,
+		RunnerLabels:      combineLabels(pool.Labels, allocation.RequestedLabels, runnerLabel),
+		RequestedLabels:   append([]string(nil), allocation.RequestedLabels...),
+		JobTimeout:        request.JobTimeout.String(),
 		JobTimeoutSeconds: int64(request.JobTimeout / time.Second),
 		GitHub: dispatchGitHub{
 			ScopeType:    b.cfg.GitHub.Scope.Type,

--- a/internal/backend/externaldispatch/backend_test.go
+++ b/internal/backend/externaldispatch/backend_test.go
@@ -109,6 +109,90 @@ func TestProvisionDispatchesRunnerLaunch(t *testing.T) {
 	}
 }
 
+func TestNewUsesBackendSpecificDispatchTimeout(t *testing.T) {
+	azureFunctionsBackend := New(model.BackendAzureFunctions, newRepoScopedConfig(), staticSecrets{})
+	codebuildBackend := New(model.BackendCodeBuild, newRepoScopedConfig(), staticSecrets{})
+
+	azureFunctionsClient, ok := azureFunctionsBackend.client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client, got %T", azureFunctionsBackend.client)
+	}
+	if azureFunctionsClient.Timeout != azureFunctionsDispatchTimeout {
+		t.Fatalf("expected azure functions timeout %s, got %s", azureFunctionsDispatchTimeout, azureFunctionsClient.Timeout)
+	}
+
+	codebuildClient, ok := codebuildBackend.client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client, got %T", codebuildBackend.client)
+	}
+	if codebuildClient.Timeout != defaultDispatchTimeout {
+		t.Fatalf("expected default dispatch timeout %s, got %s", defaultDispatchTimeout, codebuildClient.Timeout)
+	}
+}
+
+func TestProvisionAllowsAzureFunctionsColdStartLatency(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"execution_id":"run-slow","metadata":{"provider":"azure-functions"}}`))
+	}))
+	defer server.Close()
+
+	cfg := newRepoScopedConfig()
+	for index := range cfg.Pools {
+		if cfg.Pools[index].Name != model.PoolLite {
+			continue
+		}
+		azureCfg := cfg.Pools[index].Backends[model.BackendAzureFunctions]
+		azureCfg.Enabled = true
+		azureCfg.SecretRef = "uecb-azure-functions"
+		cfg.Pools[index].Backends[model.BackendAzureFunctions] = azureCfg
+	}
+
+	azureFunctionsBackend := New(model.BackendAzureFunctions, cfg, staticSecrets{
+		"uecb-azure-functions": {
+			secretKeyDispatchURL: server.URL,
+		},
+	})
+	provisioned, err := azureFunctionsBackend.Provision(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	}, model.AllocationStatus{
+		ID:   "azf-001",
+		Pool: model.PoolLite,
+	})
+	if err != nil {
+		t.Fatalf("azure functions provision failed: %v", err)
+	}
+	if provisioned.Metadata["execution_id"] != "run-slow" {
+		t.Fatalf("expected execution_id metadata, got %+v", provisioned.Metadata)
+	}
+
+	codebuildBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyDispatchURL: server.URL,
+		},
+	})
+	codebuildClient, ok := codebuildBackend.client.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default HTTP client, got %T", codebuildBackend.client)
+	}
+	codebuildClient.Timeout = 10 * time.Millisecond
+
+	_, err = codebuildBackend.Provision(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	}, model.AllocationStatus{
+		ID:   "cb-001",
+		Pool: model.PoolLite,
+	})
+	if err == nil || !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
+		t.Fatalf("expected timeout from short-lived controller call, got %v", err)
+	}
+}
+
 func TestProvisionFailsWhenSecretMissesDispatchURL(t *testing.T) {
 	cfg := newRepoScopedConfig()
 	backend := New(model.BackendCodeBuild, cfg, staticSecrets{


### PR DESCRIPTION
## Summary
- use a backend-specific dispatch timeout so Azure Functions gets a 90s cold-start window
- keep other external dispatch backends at the existing 20s timeout
- add regression tests for timeout selection and slow Azure Functions dispatch admission
- document the Azure Functions broker wait behavior

## Validation
- go test ./...
- git diff --check

No linked issue found; operational fix from Azure Functions smoke run 24873468646.