### PR TITLE
Fix capability request decoding

### DIFF
--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -42,10 +42,12 @@ func (d *durationRequestValue) UnmarshalJSON(data []byte) error {
 
 func decodeAllocationRequest(reader io.Reader) (model.AllocationRequest, error) {
 	var request struct {
-		Pool       model.PoolName       `json:"pool"`
-		Backend    *model.BackendName   `json:"backend,omitempty"`
-		JobTimeout durationRequestValue `json:"job_timeout"`
-		Labels     []string             `json:"labels,omitempty"`
+		Pool                 model.PoolName       `json:"pool"`
+		Backend              *model.BackendName   `json:"backend,omitempty"`
+		JobTimeout           durationRequestValue `json:"job_timeout"`
+		Labels               []string             `json:"labels,omitempty"`
+		RequiredCapabilities []string             `json:"required_capabilities,omitempty"`
+		ExcludedCapabilities []string             `json:"excluded_capabilities,omitempty"`
 	}
 
 	decoder := json.NewDecoder(reader)
@@ -60,9 +62,11 @@ func decodeAllocationRequest(reader io.Reader) (model.AllocationRequest, error) 
 	}
 
 	return model.AllocationRequest{
-		Pool:       request.Pool,
-		Backend:    backend,
-		JobTimeout: time.Duration(request.JobTimeout),
-		Labels:     append([]string(nil), request.Labels...),
+		Pool:                 request.Pool,
+		Backend:              backend,
+		JobTimeout:           time.Duration(request.JobTimeout),
+		Labels:               append([]string(nil), request.Labels...),
+		RequiredCapabilities: append([]string(nil), request.RequiredCapabilities...),
+		ExcludedCapabilities: append([]string(nil), request.ExcludedCapabilities...),
 	}, nil
 }

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -64,3 +64,16 @@ func TestDecodeAllocationRequestCopiesLabels(t *testing.T) {
 		t.Fatalf("unexpected labels: %#v", request.Labels)
 	}
 }
+
+func TestDecodeAllocationRequestCopiesCapabilities(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","required_capabilities":["region:gcp-us-central1"],"excluded_capabilities":["cluster-local"]}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(request.RequiredCapabilities) != 1 || request.RequiredCapabilities[0] != "region:gcp-us-central1" {
+		t.Fatalf("unexpected required capabilities: %#v", request.RequiredCapabilities)
+	}
+	if len(request.ExcludedCapabilities) != 1 || request.ExcludedCapabilities[0] != "cluster-local" {
+		t.Fatalf("unexpected excluded capabilities: %#v", request.ExcludedCapabilities)
+	}
+}


### PR DESCRIPTION
Fixes HTTP allocation request decoding so required_capabilities and excluded_capabilities reach the service-level capability filter added for #2.\n\nValidation: go test ./...\n\nRefs #2