### PR TITLE
[codex] Ship observability pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Built-in schedulers:
 - `actions/allocate-runner`: public workflow integration surface
 - `examples/`: generic Terraform and GitOps consumption examples
 - `docs/`: architecture and security notes
+- `observability/`: reusable Prometheus alert rules and Grafana dashboard artifacts
 
 ## Public CI and Private Release Boundary
 
@@ -213,6 +214,16 @@ This requires at least one backend in the selected pool to advertise `gpu`, for 
 ```
 
 If no backend matches the requested capability filters, the broker rejects the allocation request before scheduling.
+
+## Observability
+
+The broker exposes Prometheus metrics on `/metrics` and uses a shared `X-Correlation-ID` model across HTTP responses, allocation responses, and structured lifecycle logs. The reusable pack includes:
+
+- `observability/grafana-dashboard.json`
+- `observability/prometheus-rules.yaml`
+- [docs/observability.md](docs/observability.md)
+
+The pack observes allocation and backend lifecycle events without changing scheduling behavior.
 
 ## License
 

--- a/charts/unified-ephemeral-runner-broker/templates/service.yaml
+++ b/charts/unified-ephemeral-runner-broker/templates/service.yaml
@@ -2,6 +2,22 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "uecb.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "uecb.name" . }}
+{{ with .Values.service.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{ if or .Values.observability.prometheus.scrape .Values.service.annotations }}
+  annotations:
+{{- if .Values.observability.prometheus.scrape }}
+    prometheus.io/scrape: "true"
+    prometheus.io/path: {{ .Values.observability.prometheus.path | quote }}
+    prometheus.io/port: {{ .Values.service.port | quote }}
+{{- end }}
+{{ with .Values.service.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -16,6 +16,13 @@ serviceAccount:
 service:
   type: ClusterIP
   port: 8080
+  annotations: {}
+  labels: {}
+
+observability:
+  prometheus:
+    scrape: false
+    path: /metrics
 
 resources:
   requests:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,64 @@
+# Observability Pack
+
+The broker exposes Prometheus metrics on `/metrics` and propagates a shared correlation ID through HTTP responses, allocation state, and structured log fields.
+
+Prometheus scrape annotations can be enabled in the Helm chart without changing broker scheduling behavior:
+
+```yaml
+observability:
+  prometheus:
+    scrape: true
+```
+
+## Correlation Model
+
+- Clients may send `X-Correlation-ID` on broker requests.
+- If the header is absent, the broker generates one.
+- The broker returns the same value in the `X-Correlation-ID` response header.
+- Allocation responses include `correlation_id`.
+- Broker lifecycle logs include `correlation_id=<value>` with allocation, pool, backend, and error fields where available.
+
+Use the correlation ID as the join key across HTTP access logs, broker lifecycle logs, backend controller logs, and trace spans from downstream adapters.
+
+## Metrics
+
+Core metrics:
+
+- `uecb_http_requests_total{route,method,status}`: broker HTTP request count.
+- `uecb_allocations_total{pool,backend,result}`: allocation attempts and success or failure results.
+- `uecb_allocation_latency_seconds{pool,backend,result}`: end-to-end broker allocation latency.
+- `uecb_launch_latency_seconds{pool,backend}`: backend launch handoff latency.
+- `uecb_registration_latency_seconds{pool,backend}`: time until the broker has a provisioned runner label.
+- `uecb_queue_depth{pool,state}`: current allocations by state.
+- `uecb_capacity_utilization_ratio{pool,backend}`: active allocation count divided by configured backend capacity.
+
+The observability pack does not change scheduler selection, capacity reservation, or backend dispatch behavior. It only observes the existing lifecycle.
+
+## Artifacts
+
+- `observability/grafana-dashboard.json`: importable Grafana dashboard for latency, allocation rate, queue depth, and capacity utilization.
+- `observability/prometheus-rules.yaml`: Prometheus alert rules for dispatch latency, failure rate, saturated capacity, and stuck allocations.
+
+## Failure Modes
+
+High allocation latency usually means the broker can accept requests but a backend is slow to launch or register a runner. Compare `uecb_allocation_latency_seconds` with `uecb_launch_latency_seconds` and `uecb_registration_latency_seconds` by backend.
+
+High allocation failure rate means requests are being rejected or backend provisioning is failing. Check broker logs by `correlation_id`, then inspect the selected backend controller logs for the same ID.
+
+Saturated capacity means the scheduler has few or no healthy slots available for a pool/backend. Check `maxRunners`, runner cleanup, and whether completed jobs are leaving allocations in `ready` or `reserved`.
+
+Stuck queue depth means allocations are not moving to terminal states. Check expiration sweeps, backend cancellation behavior, and runner completion callbacks in the consuming environment.
+
+## Example SLOs
+
+Dispatch latency SLO:
+
+- Objective: 99 percent of successful allocations complete within 60 seconds over 30 days.
+- Indicator: `histogram_quantile(0.99, sum by (le) (rate(uecb_allocation_latency_seconds_bucket{result="success"}[30d])))`.
+- Initial alert: p95 over 60 seconds for 15 minutes.
+
+Successful runner completion SLO:
+
+- Objective: 99 percent of allocation attempts reach a usable runner label without broker-side failure over 30 days.
+- Indicator: `sum(rate(uecb_allocations_total{result="success"}[30d])) / sum(rate(uecb_allocations_total[30d]))`.
+- Initial alert: failure ratio above 5 percent for 10 minutes.

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -20,12 +19,18 @@ type Server struct {
 }
 
 func NewServer(service *Service, allowedIssuers []string, expectedAud string, allowAnon bool) *Server {
+	observer := NewPrometheusObserver(prometheus.DefaultRegisterer)
+	if err := observer.Register(prometheus.DefaultRegisterer); err != nil {
+		panic(err)
+	}
+	service.SetObserver(observer)
+
 	return &Server{
 		service:        service,
 		allowedIssuers: allowedIssuers,
 		expectedAud:    expectedAud,
 		allowAnon:      allowAnon,
-		requests: promauto.NewCounterVec(prometheus.CounterOpts{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "uecb_http_requests_total",
 			Help: "HTTP requests handled by the broker.",
 		}, []string{"route", "method", "status"}),
@@ -38,7 +43,12 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/v1/allocations/", s.handleAllocationByID)
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", s.handleHealth)
-	return mux
+	if err := prometheus.Register(s.requests); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			panic(err)
+		}
+	}
+	return s.withRequestObservability(mux)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +142,6 @@ func (s *Server) authorize(r *http.Request) error {
 }
 
 func (s *Server) writeError(w http.ResponseWriter, code int, err error) {
-	s.record("error", code, http.MethodGet)
 	s.writeJSON(w, code, map[string]string{"error": err.Error()})
 }
 
@@ -144,4 +153,39 @@ func (s *Server) writeJSON(w http.ResponseWriter, code int, body interface{}) {
 
 func (s *Server) record(route string, status int, method string) {
 	s.requests.WithLabelValues(route, method, http.StatusText(status)).Inc()
+}
+
+func (s *Server) withRequestObservability(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		correlationID := correlationIDFromRequest(r)
+		w.Header().Set(correlationIDHeader, correlationID)
+		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(recorder, r.WithContext(withCorrelationID(r.Context(), correlationID)))
+		s.record(routeName(r.URL.Path), recorder.status, r.Method)
+	})
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func routeName(path string) string {
+	switch {
+	case path == "/v1/allocations":
+		return "/v1/allocations"
+	case strings.HasPrefix(path, "/v1/allocations/"):
+		return "/v1/allocations/{id}"
+	case path == "/metrics":
+		return "/metrics"
+	case path == "/healthz":
+		return "/healthz"
+	default:
+		return "unknown"
+	}
 }

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -46,6 +46,7 @@ func TestHandleAllocationsAcceptsStringJobTimeout(t *testing.T) {
 	server := newTestServer(t, service)
 
 	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	request.Header.Set(correlationIDHeader, "test-correlation")
 	recorder := httptest.NewRecorder()
 	server.Handler().ServeHTTP(recorder, request)
 
@@ -62,9 +63,48 @@ func TestHandleAllocationsAcceptsStringJobTimeout(t *testing.T) {
 		t.Fatalf("expected ARC backend, got %s", allocation.SelectedBackend)
 	}
 
+	if allocation.CorrelationID != "test-correlation" {
+		t.Fatalf("expected response correlation id to be preserved, got %q", allocation.CorrelationID)
+	}
+
+	if recorder.Header().Get(correlationIDHeader) != "test-correlation" {
+		t.Fatalf("expected response header correlation id to be preserved, got %q", recorder.Header().Get(correlationIDHeader))
+	}
+
 	wantExpiry := time.Unix(1000, 0).Add(15 * time.Minute)
 	if !allocation.ExpiresAt.Equal(wantExpiry) {
 		t.Fatalf("expected expiry %s, got %s", wantExpiry, allocation.ExpiresAt)
+	}
+}
+
+func TestMetricsExposeAllocationSignals(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	server := newTestServer(t, service)
+	handler := server.Handler()
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected allocation to succeed, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	metrics := httptest.NewRecorder()
+	handler.ServeHTTP(metrics, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := metrics.Body.String()
+
+	for _, metric := range []string{
+		`uecb_allocations_total{backend="arc",pool="full",result="success"} 1`,
+		`uecb_queue_depth{pool="full",state="ready"} 1`,
+		`uecb_capacity_utilization_ratio{backend="arc",pool="full"} 0.25`,
+		`uecb_http_requests_total{method="POST",route="/v1/allocations",status="Created"} 1`,
+		`uecb_allocation_latency_seconds_bucket`,
+		`uecb_launch_latency_seconds_bucket`,
+		`uecb_registration_latency_seconds_bucket`,
+	} {
+		if !strings.Contains(body, metric) {
+			t.Fatalf("expected metrics to contain %q, got:\n%s", metric, body)
+		}
 	}
 }
 

--- a/internal/api/observability.go
+++ b/internal/api/observability.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	correlationIDHeader = "X-Correlation-ID"
+	correlationIDKey    = "correlation_id"
+)
+
+type contextKey string
+
+const correlationContextKey contextKey = correlationIDKey
+
+type Observer interface {
+	ObserveAllocationStart(model.PoolName)
+	ObserveAllocationResult(model.PoolName, model.BackendName, string, time.Duration)
+	ObserveLaunchLatency(model.PoolName, model.BackendName, time.Duration)
+	ObserveRegistrationLatency(model.PoolName, model.BackendName, time.Duration)
+	ObserveActiveAllocations([]model.AllocationStatus)
+	ObserveCapacity(model.BrokerConfig, []model.AllocationStatus)
+}
+
+type noopObserver struct{}
+
+func (noopObserver) ObserveAllocationStart(model.PoolName) {}
+func (noopObserver) ObserveAllocationResult(model.PoolName, model.BackendName, string, time.Duration) {
+}
+func (noopObserver) ObserveLaunchLatency(model.PoolName, model.BackendName, time.Duration) {}
+func (noopObserver) ObserveRegistrationLatency(model.PoolName, model.BackendName, time.Duration) {
+}
+func (noopObserver) ObserveActiveAllocations([]model.AllocationStatus)            {}
+func (noopObserver) ObserveCapacity(model.BrokerConfig, []model.AllocationStatus) {}
+
+type PrometheusObserver struct {
+	allocationLatency   *prometheus.HistogramVec
+	launchLatency       *prometheus.HistogramVec
+	registrationLatency *prometheus.HistogramVec
+	allocations         *prometheus.CounterVec
+	queueDepth          *prometheus.GaugeVec
+	capacityUtilization *prometheus.GaugeVec
+}
+
+func NewPrometheusObserver(registerer prometheus.Registerer) *PrometheusObserver {
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
+
+	return &PrometheusObserver{
+		allocationLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "uecb_allocation_latency_seconds",
+			Help:    "End-to-end allocation latency from broker admission through backend provisioning.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 90},
+		}, []string{"pool", "backend", "result"}),
+		launchLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "uecb_launch_latency_seconds",
+			Help:    "Backend launch latency for a selected ephemeral runner.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 90},
+		}, []string{"pool", "backend"}),
+		registrationLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "uecb_registration_latency_seconds",
+			Help:    "Observed latency until a provisioned runner registration response is available to the broker.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 90},
+		}, []string{"pool", "backend"}),
+		allocations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "uecb_allocations_total",
+			Help: "Allocation attempts by pool, backend, and result.",
+		}, []string{"pool", "backend", "result"}),
+		queueDepth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "uecb_queue_depth",
+			Help: "Current allocation count by state.",
+		}, []string{"pool", "state"}),
+		capacityUtilization: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "uecb_capacity_utilization_ratio",
+			Help: "Active allocations divided by configured backend capacity.",
+		}, []string{"pool", "backend"}),
+	}
+}
+
+func (o *PrometheusObserver) Register(registerer prometheus.Registerer) error {
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
+	for _, collector := range []prometheus.Collector{
+		o.allocationLatency,
+		o.launchLatency,
+		o.registrationLatency,
+		o.allocations,
+		o.queueDepth,
+		o.capacityUtilization,
+	} {
+		if err := registerer.Register(collector); err != nil {
+			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (o *PrometheusObserver) ObserveAllocationStart(pool model.PoolName) {
+	o.queueDepth.WithLabelValues(string(pool), string(model.StateReserved)).Inc()
+}
+
+func (o *PrometheusObserver) ObserveAllocationResult(pool model.PoolName, backend model.BackendName, result string, latency time.Duration) {
+	o.allocations.WithLabelValues(string(pool), string(backend), result).Inc()
+	o.allocationLatency.WithLabelValues(string(pool), string(backend), result).Observe(latency.Seconds())
+}
+
+func (o *PrometheusObserver) ObserveLaunchLatency(pool model.PoolName, backend model.BackendName, latency time.Duration) {
+	o.launchLatency.WithLabelValues(string(pool), string(backend)).Observe(latency.Seconds())
+}
+
+func (o *PrometheusObserver) ObserveRegistrationLatency(pool model.PoolName, backend model.BackendName, latency time.Duration) {
+	o.registrationLatency.WithLabelValues(string(pool), string(backend)).Observe(latency.Seconds())
+}
+
+func (o *PrometheusObserver) ObserveActiveAllocations(statuses []model.AllocationStatus) {
+	o.queueDepth.Reset()
+	for _, status := range statuses {
+		o.queueDepth.WithLabelValues(string(status.Pool), string(status.State)).Inc()
+	}
+}
+
+func (o *PrometheusObserver) ObserveCapacity(cfg model.BrokerConfig, statuses []model.AllocationStatus) {
+	o.capacityUtilization.Reset()
+	active := map[model.PoolName]map[model.BackendName]int{}
+	for _, status := range statuses {
+		if status.State != model.StateReady && status.State != model.StateReserved {
+			continue
+		}
+		if active[status.Pool] == nil {
+			active[status.Pool] = map[model.BackendName]int{}
+		}
+		active[status.Pool][status.SelectedBackend]++
+	}
+	for _, pool := range cfg.Pools {
+		for name, backend := range pool.Backends {
+			if !backend.Enabled || backend.MaxRunners <= 0 {
+				continue
+			}
+			used := active[pool.Name][name]
+			o.capacityUtilization.WithLabelValues(string(pool.Name), string(name)).Set(float64(used) / float64(backend.MaxRunners))
+		}
+	}
+}
+
+func withCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationContextKey, id)
+}
+
+func correlationIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(correlationContextKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+func correlationIDFromRequest(r *http.Request) string {
+	id := strings.TrimSpace(r.Header.Get(correlationIDHeader))
+	if id == "" {
+		return newID()
+	}
+	return id
+}
+
+func logAllocationEvent(ctx context.Context, event string, fields map[string]string) {
+	log.Printf("event=%s %s=%s%s", event, correlationIDKey, correlationIDFromContext(ctx), formatLogFields(fields))
+}
+
+func formatLogFields(fields map[string]string) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	for key, value := range fields {
+		builder.WriteByte(' ')
+		builder.WriteString(key)
+		builder.WriteByte('=')
+		builder.WriteString(value)
+	}
+	return builder.String()
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -22,6 +22,7 @@ type Service struct {
 	registry *backend.Registry
 	scheds   *scheduler.Registry
 	store    *store.Memory
+	observer Observer
 	initErr  error
 	health   func(context.Context) error
 	now      func() time.Time
@@ -37,13 +38,31 @@ func NewService(cfg model.BrokerConfig, registry *backend.Registry, health func(
 		registry: registry,
 		scheds:   schedulerRegistry,
 		store:    store.NewMemory(),
+		observer: noopObserver{},
 		initErr:  validateSchedulers(cfg.Pools, schedulerRegistry),
 		health:   health,
 		now:      time.Now,
 	}
 }
 
+func (s *Service) SetObserver(observer Observer) {
+	if observer == nil {
+		s.observer = noopObserver{}
+		return
+	}
+	s.observer = observer
+}
+
 func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest) (model.AllocationStatus, error) {
+	started := s.now()
+	resultPool := request.Pool
+	var resultBackend model.BackendName
+	result := "failure"
+	defer func() {
+		s.observer.ObserveAllocationResult(resultPool, resultBackend, result, s.now().Sub(started))
+		s.observeState()
+	}()
+
 	if s.initErr != nil {
 		return model.AllocationStatus{}, s.initErr
 	}
@@ -55,11 +74,16 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	if err != nil {
 		return model.AllocationStatus{}, err
 	}
+	resultPool = pool.Name
 	request.Backend = s.resolveRequestedBackend(pool, request.Backend)
 	pool, err = filterEligibleBackends(pool, request)
 	if err != nil {
 		return model.AllocationStatus{}, err
 	}
+	s.observer.ObserveAllocationStart(pool.Name)
+	logAllocationEvent(ctx, "allocation_admitted", map[string]string{
+		"pool": string(pool.Name),
+	})
 
 	timeout := request.JobTimeout
 	if timeout <= 0 {
@@ -82,9 +106,11 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	if err != nil {
 		return model.AllocationStatus{}, err
 	}
+	resultBackend = selected
 
 	allocation := model.AllocationStatus{
 		ID:              newID(),
+		CorrelationID:   correlationIDFromContext(ctx),
 		Pool:            pool.Name,
 		SelectedBackend: selected,
 		RequestedLabels: append([]string(nil), request.Labels...),
@@ -101,10 +127,20 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		return model.AllocationStatus{}, fmt.Errorf("backend implementation missing: %s", selected)
 	}
 
+	launchStarted := s.now()
 	provisioned, err := backendImpl.Provision(ctx, request, allocation)
+	launchLatency := s.now().Sub(launchStarted)
+	s.observer.ObserveLaunchLatency(pool.Name, selected, launchLatency)
+	s.observer.ObserveRegistrationLatency(pool.Name, selected, launchLatency)
 	if err != nil {
 		poolScheduler.Release(pool.Name, selected)
 		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), err.Error())
+		logAllocationEvent(ctx, "allocation_failed", map[string]string{
+			"allocation_id": allocation.ID,
+			"pool":          string(pool.Name),
+			"backend":       string(selected),
+			"error":         err.Error(),
+		})
 		return model.AllocationStatus{}, err
 	}
 
@@ -112,6 +148,12 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	allocation.Metadata = backend.WithCapabilitiesMetadata(pool.Backends[selected], provisioned.Metadata)
 	allocation.State = model.StateReady
 	s.store.Save(allocation)
+	result = "success"
+	logAllocationEvent(ctx, "allocation_ready", map[string]string{
+		"allocation_id": allocation.ID,
+		"pool":          string(pool.Name),
+		"backend":       string(selected),
+	})
 
 	return allocation, nil
 }
@@ -135,6 +177,7 @@ func (s *Service) Cancel(id string) (model.AllocationStatus, bool) {
 	if pool, err := s.resolvePool(status.Pool); err == nil {
 		s.schedulerForPool(pool).Release(status.Pool, status.SelectedBackend)
 	}
+	s.observeState()
 	return status, true
 }
 
@@ -154,7 +197,14 @@ func (s *Service) SweepExpired(now time.Time) int {
 			expired++
 		}
 	}
+	s.observeState()
 	return expired
+}
+
+func (s *Service) observeState() {
+	statuses := s.store.List()
+	s.observer.ObserveActiveAllocations(statuses)
+	s.observer.ObserveCapacity(s.cfg, statuses)
 }
 
 func (s *Service) resolvePool(name model.PoolName) (model.PoolConfig, error) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -101,6 +101,7 @@ type AllocationRequest struct {
 
 type AllocationStatus struct {
 	ID              string            `json:"allocation_id"`
+	CorrelationID   string            `json:"correlation_id,omitempty"`
 	Pool            PoolName          `json:"pool"`
 	SelectedBackend BackendName       `json:"selected_backend"`
 	RunnerLabel     string            `json:"runner_label"`

--- a/observability/grafana-dashboard.json
+++ b/observability/grafana-dashboard.json
@@ -1,0 +1,160 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, pool) (rate(uecb_allocation_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{pool}}"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, pool) (rate(uecb_allocation_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{pool}}"
+        }
+      ],
+      "title": "Allocation Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, pool, backend) (rate(uecb_launch_latency_seconds_bucket[5m])))",
+          "legendFormat": "launch p95 {{pool}}/{{backend}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, pool, backend) (rate(uecb_registration_latency_seconds_bucket[5m])))",
+          "legendFormat": "registration p95 {{pool}}/{{backend}}"
+        }
+      ],
+      "title": "Launch and Registration Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum by (pool, backend, result) (rate(uecb_allocations_total[5m]))",
+          "legendFormat": "{{pool}}/{{backend}} {{result}}"
+        }
+      ],
+      "title": "Allocation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum by (pool, state) (uecb_queue_depth)",
+          "legendFormat": "{{pool}} {{state}}"
+        }
+      ],
+      "title": "Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "uecb_capacity_utilization_ratio",
+          "legendFormat": "{{pool}}/{{backend}}"
+        }
+      ],
+      "title": "Capacity Utilization",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "uecb",
+    "github-actions",
+    "ephemeral-runners"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Unified Ephemeral Runner Broker",
+  "uid": "uecb-observability-pack",
+  "version": 1
+}

--- a/observability/prometheus-rules.yaml
+++ b/observability/prometheus-rules.yaml
@@ -1,0 +1,41 @@
+groups:
+  - name: uecb-broker
+    rules:
+      - alert: UECBDispatchLatencyHigh
+        expr: histogram_quantile(0.95, sum by (le, pool) (rate(uecb_allocation_latency_seconds_bucket[10m]))) > 60
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "UECB dispatch latency is high for pool {{ $labels.pool }}"
+          description: "The p95 allocation latency has been above 60 seconds for 15 minutes."
+
+      - alert: UECBAllocationFailureRateHigh
+        expr: |
+          sum by (pool) (rate(uecb_allocations_total{result="failure"}[10m]))
+            /
+          clamp_min(sum by (pool) (rate(uecb_allocations_total[10m])), 0.001) > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "UECB allocation failure rate is high for pool {{ $labels.pool }}"
+          description: "More than 5 percent of allocation attempts are failing over the last 10 minutes."
+
+      - alert: UECBCapacitySaturated
+        expr: uecb_capacity_utilization_ratio > 0.9
+        for: 20m
+        labels:
+          severity: warning
+        annotations:
+          summary: "UECB backend capacity is saturated for {{ $labels.pool }}/{{ $labels.backend }}"
+          description: "Active allocations are consuming more than 90 percent of configured backend capacity."
+
+      - alert: UECBQueueDepthStuck
+        expr: sum by (pool) (uecb_queue_depth{state=~"reserved|ready"}) > 0
+        for: 45m
+        labels:
+          severity: warning
+        annotations:
+          summary: "UECB allocations are not draining for pool {{ $labels.pool }}"
+          description: "Reserved or ready allocations have remained active long enough to suggest cleanup or runner completion is stuck."


### PR DESCRIPTION
## Summary
- Add broker allocation lifecycle metrics for queue depth, allocation latency, launch latency, registration latency, success/failure rate, and capacity utilization.
- Propagate `X-Correlation-ID` into responses, allocation status, and structured lifecycle log fields.
- Ship reusable observability artifacts: Grafana dashboard, Prometheus alert rules, Helm scrape opt-in values, and an operator runbook with SLO examples.

## Validation
- `go test ./...`
- `git diff --check`

## Notes
- `helm template uecb charts/unified-ephemeral-runner-broker` could not be run locally because `helm` is not installed in this environment.

Closes #8