### PR TITLE
Add priority fair-share scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,37 @@ pools:
 
 Rollback is just a config change: set `scheduler` back to `round-robin` for the pool and redeploy. Leaving `weight` values in place is safe because the default scheduler ignores them.
 
+### Priority And Fair-Share Scheduling
+
+Pools can opt into tenant-aware dispatch independently of the backend scheduler with `fairShare.enabled`.
+
+```yaml
+pools:
+  - name: lite
+    scheduler: weighted-round-robin
+    fairShare:
+      enabled: true
+      priorityClasses:
+        normal: 1
+        high: 2
+```
+
+Allocation requests may include:
+
+- `tenant`: queue, team, or workflow owner used for fair-share accounting
+- `priority_class`: priority class such as `normal` or `high`
+
+When enabled, fair-share admission prefers eligible backends with lower active load and lower active usage for the requesting tenant. Higher priority classes reduce the tenant penalty for that request, so urgent work can dispatch sooner when capacity is available. It does not preempt active runners, and allocations without a tenant use the `default` tenant bucket.
+
+```yaml
+- uses: ./actions/allocate-runner
+  with:
+    broker_url: https://broker.example.com
+    pool: lite
+    tenant: release
+    priority_class: high
+```
+
 ## Capability-Aware Routing
 
 Jobs can further narrow backend selection with optional capability filters on the allocation request:

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -19,6 +19,14 @@ inputs:
     description: Optional comma-separated labels to attach to the allocation request
     required: false
     default: ""
+  tenant:
+    description: Optional tenant or queue identity for fair-share scheduling
+    required: false
+    default: ""
+  priority_class:
+    description: Optional priority class, for example normal or high
+    required: false
+    default: ""
   required_capabilities:
     description: Optional comma-separated capability tags that the selected backend must advertise
     required: false
@@ -61,6 +69,8 @@ runs:
         INPUT_BACKEND: ${{ inputs.backend }}
         INPUT_JOB_TIMEOUT: ${{ inputs.job_timeout }}
         INPUT_LABELS: ${{ inputs.labels }}
+        INPUT_TENANT: ${{ inputs.tenant }}
+        INPUT_PRIORITY_CLASS: ${{ inputs.priority_class }}
         INPUT_REQUIRED_CAPABILITIES: ${{ inputs.required_capabilities }}
         INPUT_EXCLUDED_CAPABILITIES: ${{ inputs.excluded_capabilities }}
         INPUT_OIDC_AUDIENCE: ${{ inputs.oidc_audience }}
@@ -96,6 +106,14 @@ if backend:
 labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
 if labels:
     payload["labels"] = labels
+
+tenant = os.environ.get("INPUT_TENANT", "").strip()
+if tenant:
+    payload["tenant"] = tenant
+
+priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
+if priority_class:
+    payload["priority_class"] = priority_class
 
 required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
 if required_capabilities:

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -61,8 +61,13 @@ config:
         - x64
         - uecb
         - uecb-full
-      # Built-ins: round-robin, weighted-round-robin
+      # Backend schedulers: round-robin, weighted-round-robin
       scheduler: round-robin
+      fairShare:
+        enabled: false
+        priorityClasses:
+          normal: 1
+          high: 2
       capabilityProfile: full
       backends:
         arc:
@@ -82,8 +87,13 @@ config:
         - x64
         - uecb
         - uecb-lite
-      # Built-ins: round-robin, weighted-round-robin
+      # Backend schedulers: round-robin, weighted-round-robin
       scheduler: round-robin
+      fairShare:
+        enabled: false
+        priorityClasses:
+          normal: 1
+          high: 2
       capabilityProfile: lite
       backends:
         arc:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,8 @@ Within a selected pool, backends use `round-robin` across healthy backends with 
 
 Pools can opt into `weighted-round-robin` instead. Backend weights are configured per pool and only affect selection when that scheduler is enabled.
 
+Pools can also enable `fairShare` independently from the backend scheduler. Allocation requests may include `tenant` and `priority_class`; fair-share admission uses active allocation counts to prefer lower-loaded backends and avoid repeatedly favoring a tenant that already has active work. Priority only affects dispatch choice when capacity is available. The broker does not preempt active runners.
+
 ## Capability Filtering
 
 Capability-aware routing is evaluated before scheduler selection.

--- a/examples/gitops/kustomize/README.md
+++ b/examples/gitops/kustomize/README.md
@@ -9,3 +9,7 @@ Use it as a remote base pinned to a release ref and layer your local secrets, na
 The base config references a Kubernetes Secret named `uecb-github-app`.
 
 Create that Secret in your private overlay (or via ExternalSecret/secret manager tooling) in the same namespace as the broker. The broker checks for referenced secrets at runtime and stays unready until they exist.
+
+## Scheduler overlays
+
+The base keeps `round-robin` and `fairShare.enabled=false` as safe defaults. Private overlays can set `pools[].scheduler` to `weighted-round-robin`, enable `pools[].fairShare.enabled`, and tune `fairShare.priorityClasses` without changing live state by hand.

--- a/examples/gitops/kustomize/base/configmap.yaml
+++ b/examples/gitops/kustomize/base/configmap.yaml
@@ -23,6 +23,11 @@ data:
       - name: full
         labels: [self-hosted, linux, x64, uecb, uecb-full]
         scheduler: round-robin
+        fairShare:
+          enabled: false
+          priorityClasses:
+            normal: 1
+            high: 2
         capabilityProfile: full
         backends:
           arc:
@@ -35,6 +40,11 @@ data:
       - name: lite
         labels: [self-hosted, linux, x64, uecb, uecb-lite]
         scheduler: round-robin
+        fairShare:
+          enabled: false
+          priorityClasses:
+            normal: 1
+            high: 2
         capabilityProfile: lite
         backends:
           arc:

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -45,6 +45,8 @@ func decodeAllocationRequest(reader io.Reader) (model.AllocationRequest, error) 
 		Pool                 model.PoolName       `json:"pool"`
 		Backend              *model.BackendName   `json:"backend,omitempty"`
 		JobTimeout           durationRequestValue `json:"job_timeout"`
+		Tenant               string               `json:"tenant,omitempty"`
+		PriorityClass        string               `json:"priority_class,omitempty"`
 		Labels               []string             `json:"labels,omitempty"`
 		RequiredCapabilities []string             `json:"required_capabilities,omitempty"`
 		ExcludedCapabilities []string             `json:"excluded_capabilities,omitempty"`
@@ -65,6 +67,8 @@ func decodeAllocationRequest(reader io.Reader) (model.AllocationRequest, error) 
 		Pool:                 request.Pool,
 		Backend:              backend,
 		JobTimeout:           time.Duration(request.JobTimeout),
+		Tenant:               request.Tenant,
+		PriorityClass:        request.PriorityClass,
 		Labels:               append([]string(nil), request.Labels...),
 		RequiredCapabilities: append([]string(nil), request.RequiredCapabilities...),
 		ExcludedCapabilities: append([]string(nil), request.ExcludedCapabilities...),

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -55,6 +55,26 @@ func TestDecodeAllocationRequestParsesLambdaBackendAsString(t *testing.T) {
 	}
 }
 
+func TestDecodeAllocationRequestParsesTenant(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","tenant":"tenant-a","job_timeout":"1m"}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.Tenant != "tenant-a" {
+		t.Fatalf("expected tenant-a, got %q", request.Tenant)
+	}
+}
+
+func TestDecodeAllocationRequestParsesPriorityClass(t *testing.T) {
+	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","priority_class":"high","job_timeout":"1m"}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.PriorityClass != "high" {
+		t.Fatalf("expected high priority class, got %q", request.PriorityClass)
+	}
+}
+
 func TestDecodeAllocationRequestCopiesLabels(t *testing.T) {
 	request, err := decodeAllocationRequest(bytes.NewReader([]byte(`{"pool":"lite","labels":["a","b","c"]}`)))
 	if err != nil {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -18,14 +18,15 @@ var ErrUnknownPool = errors.New("pool is not configured")
 var ErrNoMatchingBackendCapabilities = errors.New("no backend matches the requested capabilities")
 
 type Service struct {
-	cfg      model.BrokerConfig
-	registry *backend.Registry
-	scheds   *scheduler.Registry
-	store    *store.Memory
-	observer Observer
-	initErr  error
-	health   func(context.Context) error
-	now      func() time.Time
+	cfg       model.BrokerConfig
+	registry  *backend.Registry
+	scheds    *scheduler.Registry
+	fairShare *scheduler.PriorityFairShare
+	store     *store.Memory
+	observer  Observer
+	initErr   error
+	health    func(context.Context) error
+	now       func() time.Time
 }
 
 func NewService(cfg model.BrokerConfig, registry *backend.Registry, health func(context.Context) error) *Service {
@@ -34,14 +35,15 @@ func NewService(cfg model.BrokerConfig, registry *backend.Registry, health func(
 	}
 	schedulerRegistry := scheduler.NewRegistry()
 	return &Service{
-		cfg:      cfg,
-		registry: registry,
-		scheds:   schedulerRegistry,
-		store:    store.NewMemory(),
-		observer: noopObserver{},
-		initErr:  validateSchedulers(cfg.Pools, schedulerRegistry),
-		health:   health,
-		now:      time.Now,
+		cfg:       cfg,
+		registry:  registry,
+		scheds:    schedulerRegistry,
+		fairShare: scheduler.NewPriorityFairShare(),
+		store:     store.NewMemory(),
+		observer:  noopObserver{},
+		initErr:   validateSchedulers(cfg.Pools, schedulerRegistry),
+		health:    health,
+		now:       time.Now,
 	}
 }
 
@@ -101,8 +103,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		}
 	}
 
-	poolScheduler := s.schedulerForPool(pool)
-	selected, err := poolScheduler.Reserve(pool, request.Backend)
+	selected, err := s.reserve(pool, request)
 	if err != nil {
 		return model.AllocationStatus{}, err
 	}
@@ -113,6 +114,8 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		CorrelationID:   correlationIDFromContext(ctx),
 		Pool:            pool.Name,
 		SelectedBackend: selected,
+		Tenant:          request.Tenant,
+		PriorityClass:   request.PriorityClass,
 		RequestedLabels: append([]string(nil), request.Labels...),
 		ExpiresAt:       s.now().Add(timeout),
 		State:           model.StateReserved,
@@ -122,7 +125,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 
 	backendImpl, ok := s.registry.Get(selected)
 	if !ok {
-		poolScheduler.Release(pool.Name, selected)
+		s.release(pool, selected, allocation)
 		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), "backend not registered")
 		return model.AllocationStatus{}, fmt.Errorf("backend implementation missing: %s", selected)
 	}
@@ -133,7 +136,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	s.observer.ObserveLaunchLatency(pool.Name, selected, launchLatency)
 	s.observer.ObserveRegistrationLatency(pool.Name, selected, launchLatency)
 	if err != nil {
-		poolScheduler.Release(pool.Name, selected)
+		s.release(pool, selected, allocation)
 		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), err.Error())
 		logAllocationEvent(ctx, "allocation_failed", map[string]string{
 			"allocation_id": allocation.ID,
@@ -175,7 +178,7 @@ func (s *Service) Cancel(id string) (model.AllocationStatus, bool) {
 		return model.AllocationStatus{}, false
 	}
 	if pool, err := s.resolvePool(status.Pool); err == nil {
-		s.schedulerForPool(pool).Release(status.Pool, status.SelectedBackend)
+		s.release(pool, status.SelectedBackend, status)
 	}
 	s.observeState()
 	return status, true
@@ -192,7 +195,7 @@ func (s *Service) SweepExpired(now time.Time) int {
 		}
 		if _, ok := s.store.MarkState(status.ID, model.StateExpired, now, "allocation expired"); ok {
 			if pool, err := s.resolvePool(status.Pool); err == nil {
-				s.schedulerForPool(pool).Release(status.Pool, status.SelectedBackend)
+				s.release(pool, status.SelectedBackend, status)
 			}
 			expired++
 		}
@@ -241,6 +244,26 @@ func (s *Service) schedulerForPool(pool model.PoolConfig) scheduler.Scheduler {
 		return scheduler.NewRoundRobin()
 	}
 	return s.scheds.ForPool(pool)
+}
+
+func (s *Service) reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error) {
+	if pool.FairShare.Enabled {
+		if s.fairShare == nil {
+			return scheduler.NewPriorityFairShare().Reserve(pool, request)
+		}
+		return s.fairShare.Reserve(pool, request)
+	}
+	return s.schedulerForPool(pool).Reserve(pool, request)
+}
+
+func (s *Service) release(pool model.PoolConfig, backend model.BackendName, allocation model.AllocationStatus) {
+	if pool.FairShare.Enabled {
+		if s.fairShare != nil {
+			s.fairShare.Release(pool.Name, backend, allocation)
+		}
+		return
+	}
+	s.schedulerForPool(pool).Release(pool.Name, backend, allocation)
 }
 
 func validateSchedulers(pools []model.PoolConfig, registry *scheduler.Registry) error {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -114,6 +114,62 @@ func TestAllocateUsesWeightedSchedulerForPool(t *testing.T) {
 	}
 }
 
+func TestAllocateUsesPriorityFairShareScheduler(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		pool.FairShare.Enabled = true
+
+		arcCfg := pool.Backends[model.BackendARC]
+		arcCfg.Enabled = true
+		arcCfg.MaxRunners = 4
+		pool.Backends[model.BackendARC] = arcCfg
+
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.MaxRunners = 4
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	})
+
+	pinnedArc := model.BackendARC
+	for range 2 {
+		_, err := service.Allocate(context.Background(), model.AllocationRequest{
+			Pool:          model.PoolLite,
+			Backend:       &pinnedArc,
+			Tenant:        "tenant-a",
+			PriorityClass: string(model.PriorityClassHigh),
+			JobTimeout:    5 * time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("tenant-a arc allocation failed: %v", err)
+		}
+	}
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:          model.PoolLite,
+		Tenant:        "tenant-b",
+		PriorityClass: string(model.PriorityClassNormal),
+		JobTimeout:    5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("tenant-b normal allocation failed: %v", err)
+	}
+	if allocation.SelectedBackend != model.BackendCodeBuild {
+		t.Fatalf("expected tenant-b to use fair-share low-load backend, got %s", allocation.SelectedBackend)
+	}
+	if allocation.Tenant != "tenant-b" {
+		t.Fatalf("expected tenant metadata on allocation, got %q", allocation.Tenant)
+	}
+	if allocation.PriorityClass != string(model.PriorityClassNormal) {
+		t.Fatalf("expected priority metadata on allocation, got %q", allocation.PriorityClass)
+	}
+
+	if _, ok := service.Cancel(allocation.ID); !ok {
+		t.Fatal("expected cancel to succeed")
+	}
+}
+
 func TestAllocateFailsForUnknownScheduler(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name == model.PoolLite {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -30,9 +30,16 @@ func Default() model.BrokerConfig {
 		},
 		Pools: []model.PoolConfig{
 			{
-				Name:              model.PoolFull,
-				Labels:            []string{"self-hosted", "linux", "x64", "uecb", "uecb-full"},
-				Scheduler:         "round-robin",
+				Name:      model.PoolFull,
+				Labels:    []string{"self-hosted", "linux", "x64", "uecb", "uecb-full"},
+				Scheduler: "round-robin",
+				FairShare: model.FairShareConfig{
+					Enabled: false,
+					PriorityClasses: map[string]int{
+						string(model.PriorityClassNormal): 1,
+						string(model.PriorityClassHigh):   2,
+					},
+				},
 				CapabilityProfile: model.CapabilityFull,
 				Backends: map[model.BackendName]model.BackendConfig{
 					model.BackendARC: {
@@ -46,9 +53,16 @@ func Default() model.BrokerConfig {
 				},
 			},
 			{
-				Name:              model.PoolLite,
-				Labels:            []string{"self-hosted", "linux", "x64", "uecb", "uecb-lite"},
-				Scheduler:         "round-robin",
+				Name:      model.PoolLite,
+				Labels:    []string{"self-hosted", "linux", "x64", "uecb", "uecb-lite"},
+				Scheduler: "round-robin",
+				FairShare: model.FairShareConfig{
+					Enabled: false,
+					PriorityClasses: map[string]int{
+						string(model.PriorityClassNormal): 1,
+						string(model.PriorityClassHigh):   2,
+					},
+				},
 				CapabilityProfile: model.CapabilityLite,
 				Backends: map[model.BackendName]model.BackendConfig{
 					model.BackendARC: {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -36,6 +36,13 @@ const (
 	StateFailed   AllocationState = "failed"
 )
 
+type PriorityClass string
+
+const (
+	PriorityClassNormal PriorityClass = "normal"
+	PriorityClassHigh   PriorityClass = "high"
+)
+
 type GitHubScope struct {
 	Type              string `yaml:"type" json:"type"`
 	Organization      string `yaml:"organization" json:"organization"`
@@ -76,10 +83,18 @@ type BackendConfig struct {
 	SecretRef      string        `yaml:"secretRef,omitempty" json:"secretRef,omitempty"`
 }
 
+type FairShareConfig struct {
+	Enabled         bool           `yaml:"enabled" json:"enabled"`
+	UsageWindow     time.Duration  `yaml:"usageWindow,omitempty" json:"usageWindow,omitempty"`
+	StarvationAfter time.Duration  `yaml:"starvationAfter,omitempty" json:"starvationAfter,omitempty"`
+	PriorityClasses map[string]int `yaml:"priorityClasses,omitempty" json:"priorityClasses,omitempty"`
+}
+
 type PoolConfig struct {
 	Name              PoolName                      `yaml:"name" json:"name"`
 	Labels            []string                      `yaml:"labels" json:"labels"`
 	Scheduler         string                        `yaml:"scheduler" json:"scheduler"`
+	FairShare         FairShareConfig               `yaml:"fairShare,omitempty" json:"fairShare,omitempty"`
 	CapabilityProfile CapabilityProfile             `yaml:"capabilityProfile" json:"capabilityProfile"`
 	Backends          map[BackendName]BackendConfig `yaml:"backends" json:"backends"`
 }
@@ -94,6 +109,8 @@ type AllocationRequest struct {
 	Pool                 PoolName      `json:"pool"`
 	Backend              *BackendName  `json:"backend,omitempty"`
 	JobTimeout           time.Duration `json:"job_timeout"`
+	Tenant               string        `json:"tenant,omitempty"`
+	PriorityClass        string        `json:"priority_class,omitempty"`
 	Labels               []string      `json:"labels,omitempty"`
 	RequiredCapabilities []string      `json:"required_capabilities,omitempty"`
 	ExcludedCapabilities []string      `json:"excluded_capabilities,omitempty"`
@@ -106,6 +123,8 @@ type AllocationStatus struct {
 	SelectedBackend BackendName       `json:"selected_backend"`
 	RunnerLabel     string            `json:"runner_label"`
 	RequestedLabels []string          `json:"requested_labels,omitempty"`
+	Tenant          string            `json:"tenant,omitempty"`
+	PriorityClass   string            `json:"priority_class,omitempty"`
 	ExpiresAt       time.Time         `json:"expires_at"`
 	State           AllocationState   `json:"state"`
 	Error           string            `json:"error,omitempty"`

--- a/internal/scheduler/priority_fair_share.go
+++ b/internal/scheduler/priority_fair_share.go
@@ -1,0 +1,202 @@
+package scheduler
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+const (
+	defaultNormalPriorityClass  = 1
+	defaultHighPriorityClass    = 2
+	priorityShareScale          = 1000
+	priorityShareClassBoost     = 500
+	priorityShareClassMinWeight = 1
+)
+
+type PriorityFairShare struct {
+	state *priorityFairShareState
+}
+
+func NewPriorityFairShare() *PriorityFairShare {
+	return &PriorityFairShare{
+		state: newPriorityFairShareState(),
+	}
+}
+
+func (p *PriorityFairShare) Reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error) {
+	return p.state.Reserve(pool, request)
+}
+
+func (p *PriorityFairShare) Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus) {
+	p.state.Release(pool, backend, allocation)
+}
+
+func (p *PriorityFairShare) Active(pool model.PoolName, backend model.BackendName) int {
+	return p.state.Active(pool, backend)
+}
+
+type priorityFairShareState struct {
+	mu           sync.Mutex
+	cursors      map[model.PoolName]int
+	active       map[model.PoolName]map[model.BackendName]int
+	tenantActive map[model.PoolName]map[model.BackendName]map[string]int
+}
+
+func newPriorityFairShareState() *priorityFairShareState {
+	return &priorityFairShareState{
+		cursors:      map[model.PoolName]int{},
+		active:       map[model.PoolName]map[model.BackendName]int{},
+		tenantActive: map[model.PoolName]map[model.BackendName]map[string]int{},
+	}
+}
+
+func (s *priorityFairShareState) Reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.active[pool.Name]; !ok {
+		s.active[pool.Name] = map[model.BackendName]int{}
+	}
+	if _, ok := s.tenantActive[pool.Name]; !ok {
+		s.tenantActive[pool.Name] = map[model.BackendName]map[string]int{}
+	}
+
+	pinned := request.Backend
+	if pinned != nil {
+		cfg, ok := pool.Backends[*pinned]
+		if !ok {
+			return "", ErrUnknownBackend
+		}
+		if !backendAvailable(cfg, s.active[pool.Name][*pinned]) {
+			return "", ErrNoCapacity
+		}
+		s.active[pool.Name][*pinned]++
+		tenantMap := s.tenantActive[pool.Name][*pinned]
+		if tenantMap == nil {
+			tenantMap = map[string]int{}
+			s.tenantActive[pool.Name][*pinned] = tenantMap
+		}
+		tenantMap[normalizeTenant(request.Tenant)]++
+		return *pinned, nil
+	}
+
+	backends := orderedBackends(pool)
+	if len(backends) == 0 {
+		return "", ErrNoCapacity
+	}
+
+	var (
+		bestIndex  = -1
+		bestScore  = 0
+		bestOffset = 0
+	)
+
+	priorityWeight := normalizePriorityClassWeight(pool, request.PriorityClass)
+	tenant := normalizeTenant(request.Tenant)
+	start := s.cursors[pool.Name] % len(backends)
+
+	for offset := 0; offset < len(backends); offset++ {
+		candidate := backends[(start+offset)%len(backends)]
+		cfg := pool.Backends[candidate]
+		active := s.active[pool.Name][candidate]
+		if !backendAvailable(cfg, active) {
+			continue
+		}
+
+		normalizedTenant := s.tenantActive[pool.Name][candidate][tenant]
+		score := priorityFairShareScore(active, normalizedTenant, priorityWeight)
+		if bestIndex == -1 || score < bestScore || (score == bestScore && offset < bestOffset) {
+			bestIndex = (start + offset) % len(backends)
+			bestScore = score
+			bestOffset = offset
+		}
+	}
+
+	if bestIndex < 0 {
+		return "", ErrNoCapacity
+	}
+
+	selected := backends[bestIndex]
+	s.active[pool.Name][selected]++
+	tenantMap := s.tenantActive[pool.Name][selected]
+	if tenantMap == nil {
+		tenantMap = map[string]int{}
+		s.tenantActive[pool.Name][selected] = tenantMap
+	}
+	s.tenantActive[pool.Name][selected][tenant]++
+	s.cursors[pool.Name] = (bestIndex + 1) % len(backends)
+	return selected, nil
+}
+
+func (s *priorityFairShareState) Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	poolActive, ok := s.active[pool]
+	if !ok {
+		return
+	}
+
+	if poolActive[backend] > 0 {
+		poolActive[backend]--
+	}
+
+	tenant := normalizeTenant(allocation.Tenant)
+	if tenantBackends, ok := s.tenantActive[pool]; ok {
+		tenantCounts := tenantBackends[backend]
+		if tenantCounts == nil {
+			return
+		}
+		if tenantCounts[tenant] > 0 {
+			tenantCounts[tenant]--
+			if tenantCounts[tenant] == 0 {
+				delete(tenantCounts, tenant)
+			}
+		}
+	}
+}
+
+func (s *priorityFairShareState) Active(pool model.PoolName, backend model.BackendName) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active[pool][backend]
+}
+
+func priorityFairShareScore(activeTotal, tenantActive, weight int) int {
+	if weight < priorityShareClassMinWeight {
+		weight = priorityShareClassMinWeight
+	}
+	tenantPenalty := (tenantActive * priorityShareScale) / weight
+	return activeTotal*priorityShareScale + tenantPenalty - (weight-1)*priorityShareClassBoost
+}
+
+func normalizePriorityClassWeight(pool model.PoolConfig, requestPriorityClass string) int {
+	normalized := strings.TrimSpace(strings.ToLower(requestPriorityClass))
+	if normalized == "" {
+		return defaultNormalPriorityClass
+	}
+
+	if pool.FairShare.PriorityClasses != nil {
+		if weight, ok := pool.FairShare.PriorityClasses[normalized]; ok && weight > 0 {
+			return weight
+		}
+	}
+
+	switch model.PriorityClass(normalized) {
+	case model.PriorityClassHigh:
+		return defaultHighPriorityClass
+	case model.PriorityClassNormal:
+		return defaultNormalPriorityClass
+	}
+	return defaultNormalPriorityClass
+}
+
+func normalizeTenant(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "default"
+	}
+	return strings.ToLower(value)
+}

--- a/internal/scheduler/registry.go
+++ b/internal/scheduler/registry.go
@@ -13,8 +13,8 @@ const (
 )
 
 type Scheduler interface {
-	Reserve(pool model.PoolConfig, pinned *model.BackendName) (model.BackendName, error)
-	Release(pool model.PoolName, backend model.BackendName)
+	Reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error)
+	Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus)
 	Active(pool model.PoolName, backend model.BackendName) int
 }
 

--- a/internal/scheduler/round_robin.go
+++ b/internal/scheduler/round_robin.go
@@ -21,12 +21,12 @@ func NewRoundRobin() *RoundRobin {
 	}
 }
 
-func (r *RoundRobin) Reserve(pool model.PoolConfig, pinned *model.BackendName) (model.BackendName, error) {
-	return r.state.Reserve(pool, pinned)
+func (r *RoundRobin) Reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error) {
+	return r.state.Reserve(pool, request)
 }
 
-func (r *RoundRobin) Release(pool model.PoolName, backend model.BackendName) {
-	r.state.Release(pool, backend)
+func (r *RoundRobin) Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus) {
+	r.state.Release(pool, backend, allocation)
 }
 
 func (r *RoundRobin) Active(pool model.PoolName, backend model.BackendName) int {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -16,17 +16,25 @@ func poolByName(name model.PoolName) model.PoolConfig {
 	panic("pool not found")
 }
 
+func allocationRequest(pinned *model.BackendName, tenant, priority string) model.AllocationRequest {
+	return model.AllocationRequest{
+		Backend:       pinned,
+		Tenant:        tenant,
+		PriorityClass: priority,
+	}
+}
+
 func TestRoundRobinSkipsUnhealthyBackend(t *testing.T) {
 	scheduler := NewRoundRobin()
 	pool := poolByName(model.PoolLite)
 	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: false, MaxRunners: 1}
 	pool.Backends[model.BackendCloudRun] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1}
 
-	first, err := scheduler.Reserve(pool, nil)
+	first, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve #1 failed: %v", err)
 	}
-	second, err := scheduler.Reserve(pool, nil)
+	second, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve #2 failed: %v", err)
 	}
@@ -43,11 +51,11 @@ func TestRoundRobinSkipsFullBackend(t *testing.T) {
 	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1}
 	pool.Backends[model.BackendCloudRun] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1}
 
-	first, err := scheduler.Reserve(pool, nil)
+	first, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve #1 failed: %v", err)
 	}
-	second, err := scheduler.Reserve(pool, nil)
+	second, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve #2 failed: %v", err)
 	}
@@ -63,7 +71,7 @@ func TestRoundRobinPinnedBackendUsesCapacity(t *testing.T) {
 	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1}
 
 	pinned := model.BackendCodeBuild
-	selected, err := scheduler.Reserve(pool, &pinned)
+	selected, err := scheduler.Reserve(pool, allocationRequest(&pinned, "", ""))
 	if err != nil {
 		t.Fatalf("reserve failed: %v", err)
 	}
@@ -71,7 +79,7 @@ func TestRoundRobinPinnedBackendUsesCapacity(t *testing.T) {
 		t.Fatalf("expected codebuild, got %s", selected)
 	}
 
-	if _, err := scheduler.Reserve(pool, &pinned); err == nil {
+	if _, err := scheduler.Reserve(pool, allocationRequest(&pinned, "", "")); err == nil {
 		t.Fatal("expected capacity exhaustion for pinned backend")
 	}
 }
@@ -82,11 +90,11 @@ func TestRoundRobinReleaseReturnsCapacity(t *testing.T) {
 	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1}
 
 	pinned := model.BackendCodeBuild
-	if _, err := scheduler.Reserve(pool, &pinned); err != nil {
+	if _, err := scheduler.Reserve(pool, allocationRequest(&pinned, "", "")); err != nil {
 		t.Fatalf("reserve failed: %v", err)
 	}
-	scheduler.Release(pool.Name, model.BackendCodeBuild)
-	if _, err := scheduler.Reserve(pool, &pinned); err != nil {
+	scheduler.Release(pool.Name, model.BackendCodeBuild, model.AllocationStatus{})
+	if _, err := scheduler.Reserve(pool, allocationRequest(&pinned, "", "")); err != nil {
 		t.Fatalf("expected capacity to be available after release: %v", err)
 	}
 }
@@ -106,14 +114,14 @@ func TestWeightedRoundRobinUsesWeights(t *testing.T) {
 	}
 
 	for index, expected := range want {
-		selected, err := scheduler.Reserve(pool, nil)
+		selected, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 		if err != nil {
 			t.Fatalf("reserve #%d failed: %v", index+1, err)
 		}
 		if selected != expected {
 			t.Fatalf("reserve #%d selected %s, want %s", index+1, selected, expected)
 		}
-		scheduler.Release(pool.Name, selected)
+		scheduler.Release(pool.Name, selected, model.AllocationStatus{})
 	}
 }
 
@@ -125,7 +133,7 @@ func TestWeightedRoundRobinSkipsUnhealthyBackendDeterministically(t *testing.T) 
 	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: false, MaxRunners: 1, Weight: 3}
 	pool.Backends[model.BackendCloudRun] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1, Weight: 2}
 
-	selected, err := scheduler.Reserve(pool, nil)
+	selected, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve failed: %v", err)
 	}
@@ -142,7 +150,7 @@ func TestWeightedRoundRobinSkipsFullBackendDeterministically(t *testing.T) {
 	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1, Weight: 3}
 	pool.Backends[model.BackendCloudRun] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 1, Weight: 2}
 
-	first, err := scheduler.Reserve(pool, nil)
+	first, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve #1 failed: %v", err)
 	}
@@ -150,11 +158,38 @@ func TestWeightedRoundRobinSkipsFullBackendDeterministically(t *testing.T) {
 		t.Fatalf("expected codebuild first, got %s", first)
 	}
 
-	second, err := scheduler.Reserve(pool, nil)
+	second, err := scheduler.Reserve(pool, allocationRequest(nil, "", ""))
 	if err != nil {
 		t.Fatalf("reserve #2 failed: %v", err)
 	}
 	if second != model.BackendCloudRun {
 		t.Fatalf("expected deterministic fallback to cloud-run, got %s", second)
+	}
+}
+
+func TestPriorityFairShareAllocatesByTenantShareWithoutPreemption(t *testing.T) {
+	scheduler := NewPriorityFairShare()
+	pool := poolByName(model.PoolLite)
+	pool.FairShare.Enabled = true
+	pool.Backends[model.BackendARC] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 4}
+	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 4}
+	pool.FairShare.PriorityClasses = map[string]int{
+		string(model.PriorityClassNormal): 1,
+		string(model.PriorityClassHigh):   2,
+	}
+
+	pinned := model.BackendARC
+	for i := 0; i < 2; i++ {
+		if _, err := scheduler.Reserve(pool, allocationRequest(&pinned, "tenant-a", string(model.PriorityClassNormal))); err != nil {
+			t.Fatalf("setup reserve #%d failed: %v", i+1, err)
+		}
+	}
+
+	selected, err := scheduler.Reserve(pool, allocationRequest(nil, "tenant-b", string(model.PriorityClassNormal)))
+	if err != nil {
+		t.Fatalf("tenant-b reserve failed: %v", err)
+	}
+	if selected != model.BackendCodeBuild {
+		t.Fatalf("expected fair-share to avoid tenant-a-heavy backend, got %s", selected)
 	}
 }

--- a/internal/scheduler/stateful.go
+++ b/internal/scheduler/stateful.go
@@ -21,7 +21,7 @@ func newOrderedScheduler(order func(model.PoolConfig) []model.BackendName) *orde
 	}
 }
 
-func (s *orderedScheduler) Reserve(pool model.PoolConfig, pinned *model.BackendName) (model.BackendName, error) {
+func (s *orderedScheduler) Reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -29,6 +29,7 @@ func (s *orderedScheduler) Reserve(pool model.PoolConfig, pinned *model.BackendN
 		s.active[pool.Name] = map[model.BackendName]int{}
 	}
 
+	pinned := request.Backend
 	if pinned != nil {
 		cfg, ok := pool.Backends[*pinned]
 		if !ok {
@@ -61,7 +62,8 @@ func (s *orderedScheduler) Reserve(pool model.PoolConfig, pinned *model.BackendN
 	return "", ErrNoCapacity
 }
 
-func (s *orderedScheduler) Release(pool model.PoolName, backend model.BackendName) {
+func (s *orderedScheduler) Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus) {
+	_ = allocation
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/scheduler/weighted_round_robin.go
+++ b/internal/scheduler/weighted_round_robin.go
@@ -12,12 +12,12 @@ func NewWeightedRoundRobin() *WeightedRoundRobin {
 	}
 }
 
-func (w *WeightedRoundRobin) Reserve(pool model.PoolConfig, pinned *model.BackendName) (model.BackendName, error) {
-	return w.state.Reserve(pool, pinned)
+func (w *WeightedRoundRobin) Reserve(pool model.PoolConfig, request model.AllocationRequest) (model.BackendName, error) {
+	return w.state.Reserve(pool, request)
 }
 
-func (w *WeightedRoundRobin) Release(pool model.PoolName, backend model.BackendName) {
-	w.state.Release(pool, backend)
+func (w *WeightedRoundRobin) Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus) {
+	w.state.Release(pool, backend, allocation)
 }
 
 func (w *WeightedRoundRobin) Active(pool model.PoolName, backend model.BackendName) int {


### PR DESCRIPTION
Closes #4.

## Summary
- add optional allocation `tenant` and `priority_class` request metadata
- add per-pool `fairShare` config so tenant-aware dispatch is opt-in and separate from backend scheduler selection
- preserve existing `round-robin` / `weighted-round-robin` backend schedulers and default behavior
- expose tenant and priority inputs through `actions/allocate-runner`
- document Helm/Kustomize configuration and scheduler behavior

## Validation
- `go test ./...`
- `git diff --check`
- tester subagent returned `READY_FOR_PR` after final architecture correction