### PR TITLE
feat: enforce tenant quotas in PriorityFairShare scheduler

### DIFF
--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -497,3 +497,38 @@ func TestAllocateRejectsPinnedBackendThatFailsCapabilityFilter(t *testing.T) {
 		t.Fatalf("expected pinned backend error context, got %v", err)
 	}
 }
+
+func TestAllocateEnforcesTenantQuotas(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		pool.FairShare.Enabled = true
+		pool.FairShare.Quotas = map[string]int{
+			"limited-tenant": 1,
+		}
+
+		arcCfg := pool.Backends[model.BackendARC]
+		arcCfg.Enabled = true
+		arcCfg.MaxRunners = 4
+		pool.Backends[model.BackendARC] = arcCfg
+	})
+
+	// First allocation for limited-tenant should succeed
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:   model.PoolLite,
+		Tenant: "limited-tenant",
+	})
+	if err != nil {
+		t.Fatalf("first allocate failed: %v", err)
+	}
+
+	// Second allocation for limited-tenant should be rejected
+	_, err = service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:   model.PoolLite,
+		Tenant: "limited-tenant",
+	})
+	if !errors.Is(err, scheduler.ErrQuotaExceeded) {
+		t.Fatalf("expected ErrQuotaExceeded, got %v", err)
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -88,6 +88,7 @@ type FairShareConfig struct {
 	UsageWindow     time.Duration  `yaml:"usageWindow,omitempty" json:"usageWindow,omitempty"`
 	StarvationAfter time.Duration  `yaml:"starvationAfter,omitempty" json:"starvationAfter,omitempty"`
 	PriorityClasses map[string]int `yaml:"priorityClasses,omitempty" json:"priorityClasses,omitempty"`
+	Quotas          map[string]int `yaml:"quotas,omitempty" json:"quotas,omitempty"`
 }
 
 type PoolConfig struct {

--- a/internal/scheduler/priority_fair_share.go
+++ b/internal/scheduler/priority_fair_share.go
@@ -1,11 +1,14 @@
 package scheduler
 
 import (
+	"errors"
 	"strings"
 	"sync"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
+
+var ErrQuotaExceeded = errors.New("tenant quota exceeded")
 
 const (
 	defaultNormalPriorityClass  = 1
@@ -63,6 +66,17 @@ func (s *priorityFairShareState) Reserve(pool model.PoolConfig, request model.Al
 		s.tenantActive[pool.Name] = map[model.BackendName]map[string]int{}
 	}
 
+	tenant := normalizeTenant(request.Tenant)
+	if quota, ok := pool.FairShare.Quotas[tenant]; ok {
+		tenantTotal := 0
+		for _, counts := range s.tenantActive[pool.Name] {
+			tenantTotal += counts[tenant]
+		}
+		if tenantTotal >= quota {
+			return "", ErrQuotaExceeded
+		}
+	}
+
 	pinned := request.Backend
 	if pinned != nil {
 		cfg, ok := pool.Backends[*pinned]
@@ -94,7 +108,6 @@ func (s *priorityFairShareState) Reserve(pool model.PoolConfig, request model.Al
 	)
 
 	priorityWeight := normalizePriorityClassWeight(pool, request.PriorityClass)
-	tenant := normalizeTenant(request.Tenant)
 	start := s.cursors[pool.Name] % len(backends)
 
 	for offset := 0; offset < len(backends); offset++ {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -193,3 +193,39 @@ func TestPriorityFairShareAllocatesByTenantShareWithoutPreemption(t *testing.T) 
 		t.Fatalf("expected fair-share to avoid tenant-a-heavy backend, got %s", selected)
 	}
 }
+
+func TestPriorityFairShareEnforcesTenantQuotas(t *testing.T) {
+	scheduler := NewPriorityFairShare()
+	pool := poolByName(model.PoolLite)
+	pool.FairShare.Enabled = true
+	pool.FairShare.Quotas = map[string]int{
+		"limited-tenant": 1,
+	}
+	pool.Backends[model.BackendARC] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 4}
+	pool.Backends[model.BackendCodeBuild] = model.BackendConfig{Enabled: true, Healthy: true, MaxRunners: 4}
+
+	// First allocation for limited-tenant should succeed
+	_, err := scheduler.Reserve(pool, allocationRequest(nil, "limited-tenant", ""))
+	if err != nil {
+		t.Fatalf("first reserve failed: %v", err)
+	}
+
+	// Second allocation for limited-tenant should be rejected
+	_, err = scheduler.Reserve(pool, allocationRequest(nil, "limited-tenant", ""))
+	if err != ErrQuotaExceeded {
+		t.Fatalf("expected ErrQuotaExceeded, got %v", err)
+	}
+
+	// Allocation for another tenant should still succeed
+	_, err = scheduler.Reserve(pool, allocationRequest(nil, "other-tenant", ""))
+	if err != nil {
+		t.Fatalf("other-tenant reserve failed: %v", err)
+	}
+
+	// Releasing the first allocation should allow a new one
+	scheduler.Release(pool.Name, model.BackendARC, model.AllocationStatus{Tenant: "limited-tenant"})
+	_, err = scheduler.Reserve(pool, allocationRequest(nil, "limited-tenant", ""))
+	if err != nil {
+		t.Fatalf("reserve after release failed: %v", err)
+	}
+}


### PR DESCRIPTION
This PR implements tenant quota enforcement as requested in #3. 

It adds a \Quotas\ map to \FairShareConfig\ and updates the \PriorityFairShare\ scheduler to verify that a tenant has not exceeded their concurrent allocation limit across the entire pool before reserving a backend.

Tests have been added to verify strict enforcement and capacity release.