### PR TITLE
Install Node in provider runner images

### DIFF
--- a/Dockerfile.azure-functions
+++ b/Dockerfile.azure-functions
@@ -16,6 +16,7 @@ RUN set -eux; \
     git \
     gzip \
     jq \
+    nodejs \
     tar \
     unzip \
     "${libicu_pkg}"; \

--- a/Dockerfile.cloud-run
+++ b/Dockerfile.cloud-run
@@ -13,6 +13,7 @@ RUN apt-get update \
     gzip \
     jq \
     libicu74 \
+    nodejs \
     python3 \
     tar \
     unzip \

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -15,6 +15,7 @@ RUN apt-get update \
     gzip \
     jq \
     libicu74 \
+    nodejs \
     python3 \
     python3-pip \
     tar \

--- a/internal/imagecontracts/image_contracts_test.go
+++ b/internal/imagecontracts/image_contracts_test.go
@@ -31,17 +31,20 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 		"Dockerfile.lambda": {
 			"COPY docker/lambda/handler.py /var/task/handler.py",
 			"awslambdaric boto3",
+			"nodejs",
 			"UECB_PROVIDER=lambda",
 			"RUNNER_ALLOW_RUNASROOT=1",
 		},
 		"Dockerfile.cloud-run": {
 			"COPY docker/launcher/entrypoint.sh /bootstrap/entrypoint.sh",
+			"nodejs",
 			"UECB_PROVIDER=cloud-run",
 			"RUNNER_ALLOW_RUNASROOT=1",
 		},
 		"Dockerfile.azure-functions": {
 			"COPY docker/azure-functions/function_app.py /home/site/wwwroot/function_app.py",
 			"COPY docker/launcher/entrypoint.sh /opt/uecb/runner-entrypoint.sh",
+			"nodejs",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- install Node.js in the Lambda, Cloud Run, and Azure Functions provider runner images
- extend image contract tests so provider runner images must keep Node installed

Refs #8

## Testing
- go test ./...
- git diff --check
- docker build -f Dockerfile.lambda -t uecb-lambda-node-check .
- docker run --rm --entrypoint /usr/bin/env uecb-lambda-node-check node --version
