### PR TITLE
Install Node in provider runners and fix allocation admission

### DIFF
--- a/Dockerfile.azure-functions
+++ b/Dockerfile.azure-functions
@@ -16,6 +16,7 @@ RUN set -eux; \
     git \
     gzip \
     jq \
+    nodejs \
     tar \
     unzip \
     "${libicu_pkg}"; \

--- a/Dockerfile.cloud-run
+++ b/Dockerfile.cloud-run
@@ -13,6 +13,7 @@ RUN apt-get update \
     gzip \
     jq \
     libicu74 \
+    nodejs \
     python3 \
     tar \
     unzip \

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -15,6 +15,7 @@ RUN apt-get update \
     gzip \
     jq \
     libicu74 \
+    nodejs \
     python3 \
     python3-pip \
     tar \

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -78,28 +78,22 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	}
 	resultPool = pool.Name
 	request.Backend = s.resolveRequestedBackend(pool, request.Backend)
-	pool, err = filterEligibleBackends(pool, request)
-	if err != nil {
-		return model.AllocationStatus{}, err
-	}
-	s.observer.ObserveAllocationStart(pool.Name)
-	logAllocationEvent(ctx, "allocation_admitted", map[string]string{
-		"pool": string(pool.Name),
-	})
 
+	explicitTimeout := request.JobTimeout > 0
 	timeout := request.JobTimeout
 	if timeout <= 0 {
 		timeout = s.cfg.Broker.DefaultJobTimeout
 	}
 	request.JobTimeout = timeout
 
-	if request.Backend != nil {
-		backendCfg, ok := pool.Backends[*request.Backend]
-		if !ok {
-			return model.AllocationStatus{}, scheduler.ErrUnknownBackend
-		}
-		if backendCfg.MaxJobDuration > 0 && timeout > backendCfg.MaxJobDuration {
-			return model.AllocationStatus{}, fmt.Errorf("requested timeout %s exceeds backend limit %s", timeout, backendCfg.MaxJobDuration)
+	pool, err = filterEligibleBackends(pool, request)
+	if err != nil {
+		return model.AllocationStatus{}, err
+	}
+	if explicitTimeout {
+		pool, err = filterBackendsByTimeout(pool, request)
+		if err != nil {
+			return model.AllocationStatus{}, err
 		}
 	}
 
@@ -108,6 +102,11 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		return model.AllocationStatus{}, err
 	}
 	resultBackend = selected
+	s.observer.ObserveAllocationStart(pool.Name)
+	logAllocationEvent(ctx, "allocation_admitted", map[string]string{
+		"pool":    string(pool.Name),
+		"backend": string(selected),
+	})
 
 	allocation := model.AllocationStatus{
 		ID:              newID(),
@@ -304,6 +303,39 @@ func filterEligibleBackends(pool model.PoolConfig, request model.AllocationReque
 
 	if len(filtered.Backends) == 0 {
 		return model.PoolConfig{}, fmt.Errorf("%w for pool %q", ErrNoMatchingBackendCapabilities, pool.Name)
+	}
+
+	return filtered, nil
+}
+
+func filterBackendsByTimeout(pool model.PoolConfig, request model.AllocationRequest) (model.PoolConfig, error) {
+	timeout := request.JobTimeout
+	if timeout <= 0 {
+		return pool, nil
+	}
+
+	filtered := pool
+	filtered.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+	for name, cfg := range pool.Backends {
+		if cfg.MaxJobDuration > 0 && timeout > cfg.MaxJobDuration {
+			continue
+		}
+		filtered.Backends[name] = cfg
+	}
+
+	if request.Backend != nil {
+		cfg, ok := pool.Backends[*request.Backend]
+		if !ok {
+			return model.PoolConfig{}, scheduler.ErrUnknownBackend
+		}
+		if cfg.MaxJobDuration > 0 && timeout > cfg.MaxJobDuration {
+			return model.PoolConfig{}, fmt.Errorf("requested timeout %s exceeds backend limit %s", timeout, cfg.MaxJobDuration)
+		}
+		return filtered, nil
+	}
+
+	if len(filtered.Backends) == 0 {
+		return model.PoolConfig{}, fmt.Errorf("%w for pool %q with timeout %s", scheduler.ErrNoCapacity, pool.Name, timeout)
 	}
 
 	return filtered, nil

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -216,6 +216,42 @@ func TestAllocateRespectsPinnedBackendTimeoutLimit(t *testing.T) {
 	}
 }
 
+func TestAllocateSkipsBackendsThatCannotSatisfyTimeout(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, cfg := range pool.Backends {
+			cfg.Enabled = false
+			pool.Backends[name] = cfg
+		}
+		lambdaCfg := pool.Backends[model.BackendLambda]
+		lambdaCfg.Enabled = true
+		lambdaCfg.Healthy = true
+		lambdaCfg.MaxRunners = 1
+		lambdaCfg.MaxJobDuration = 15 * time.Minute
+		pool.Backends[model.BackendLambda] = lambdaCfg
+	})
+
+	if _, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 20 * time.Minute,
+	}); !errors.Is(err, scheduler.ErrNoCapacity) {
+		t.Fatalf("expected timeout-ineligible backend to be skipped as no capacity, got %v", err)
+	}
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("expected later valid allocation to use available lambda capacity: %v", err)
+	}
+	if allocation.SelectedBackend != model.BackendLambda {
+		t.Fatalf("expected lambda backend, got %s", allocation.SelectedBackend)
+	}
+}
+
 func TestAllocateTreatsLegacyPinnedLambdaAsCodeBuildWhenLambdaBackendIsDisabled(t *testing.T) {
 	service := newService()
 	backend := model.BackendLambda

--- a/internal/imagecontracts/image_contracts_test.go
+++ b/internal/imagecontracts/image_contracts_test.go
@@ -31,17 +31,20 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 		"Dockerfile.lambda": {
 			"COPY docker/lambda/handler.py /var/task/handler.py",
 			"awslambdaric boto3",
+			"nodejs",
 			"UECB_PROVIDER=lambda",
 			"RUNNER_ALLOW_RUNASROOT=1",
 		},
 		"Dockerfile.cloud-run": {
 			"COPY docker/launcher/entrypoint.sh /bootstrap/entrypoint.sh",
+			"nodejs",
 			"UECB_PROVIDER=cloud-run",
 			"RUNNER_ALLOW_RUNASROOT=1",
 		},
 		"Dockerfile.azure-functions": {
 			"COPY docker/azure-functions/function_app.py /home/site/wwwroot/function_app.py",
 			"COPY docker/launcher/entrypoint.sh /opt/uecb/runner-entrypoint.sh",
+			"nodejs",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- install Node in provider runner images so Node-based actions can run outside CodeBuild
- validate explicit job timeout limits before admitting/reserving runner capacity
- skip timeout-ineligible backends for explicit requests and cover the Lambda over-timeout regression

## Testing
- go test ./...

Refs Josh-Archer/unified-ephemeral-runner-broker#8