### PR TITLE
Install Node 24 in provider runner images

### DIFF
--- a/Dockerfile.azure-functions
+++ b/Dockerfile.azure-functions
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/azure-functions/python:4-python3.11
 ENV DEBIAN_FRONTEND=noninteractive \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    NODE_MAJOR=24
 
 RUN set -eux; \
   apt-get update; \
@@ -16,10 +17,12 @@ RUN set -eux; \
     git \
     gzip \
     jq \
-    nodejs \
     tar \
     unzip \
     "${libicu_pkg}"; \
+  curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
+  apt-get install -y --no-install-recommends nodejs; \
+  node --version; \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/site/wwwroot

--- a/Dockerfile.cloud-run
+++ b/Dockerfile.cloud-run
@@ -2,7 +2,8 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     RUNNER_ALLOW_RUNASROOT=1 \
-    UECB_PROVIDER=cloud-run
+    UECB_PROVIDER=cloud-run \
+    NODE_MAJOR=24
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -13,10 +14,12 @@ RUN apt-get update \
     gzip \
     jq \
     libicu74 \
-    nodejs \
     python3 \
     tar \
     unzip \
+  && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && node --version \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bootstrap

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     RUNNER_ALLOW_RUNASROOT=1 \
-    UECB_PROVIDER=lambda
+    UECB_PROVIDER=lambda \
+    NODE_MAJOR=24
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -15,11 +16,13 @@ RUN apt-get update \
     gzip \
     jq \
     libicu74 \
-    nodejs \
     python3 \
     python3-pip \
     tar \
     unzip \
+  && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && node --version \
   && python3 -m pip install --break-system-packages --no-cache-dir awslambdaric boto3 \
   && mkdir -p /bootstrap /opt/uecb /var/task \
   && rm -rf /var/lib/apt/lists/*

--- a/internal/imagecontracts/image_contracts_test.go
+++ b/internal/imagecontracts/image_contracts_test.go
@@ -32,12 +32,16 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 			"COPY docker/lambda/handler.py /var/task/handler.py",
 			"awslambdaric boto3",
 			"nodejs",
+			"NODE_MAJOR=24",
+			"https://deb.nodesource.com/setup_${NODE_MAJOR}.x",
 			"UECB_PROVIDER=lambda",
 			"RUNNER_ALLOW_RUNASROOT=1",
 		},
 		"Dockerfile.cloud-run": {
 			"COPY docker/launcher/entrypoint.sh /bootstrap/entrypoint.sh",
 			"nodejs",
+			"NODE_MAJOR=24",
+			"https://deb.nodesource.com/setup_${NODE_MAJOR}.x",
 			"UECB_PROVIDER=cloud-run",
 			"RUNNER_ALLOW_RUNASROOT=1",
 		},
@@ -45,6 +49,8 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 			"COPY docker/azure-functions/function_app.py /home/site/wwwroot/function_app.py",
 			"COPY docker/launcher/entrypoint.sh /opt/uecb/runner-entrypoint.sh",
 			"nodejs",
+			"NODE_MAJOR=24",
+			"https://deb.nodesource.com/setup_${NODE_MAJOR}.x",
 		},
 	}
 


### PR DESCRIPTION
Fixes the non-CodeBuild OpenTofu validation failure found while moving home workflows to UECB. Lambda runners were still exposing distro Node 18 first on PATH, and the OpenTofu action wrapper now requires a modern Node runtime.\n\nChanges:\n- Install Node 24 from NodeSource in Lambda, Cloud Run, and Azure Functions provider images.\n- Assert the Node 24 image contract in tests.\n\nValidation:\n- go test ./...\n- docker build -f Dockerfile.lambda -t uecb-lambda-node24-check .\n- docker run --rm --entrypoint node uecb-lambda-node24-check --version => v24.15.0\n\nRelated home validation run: Josh-Archer/home/actions/runs/25183994907 landed on uecb-lambda-29040cd5732c4d4b and failed at tofu wrapper execution with Node.js v18.19.1.