### PR TITLE
Add orphan cleanup and completion workflow (Issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,35 @@ sequenceDiagram
 5. The heavy workflow job runs on that exact label.
 6. The runner executes one job and exits.
 
+### Completion Callback Endpoint
+
+The broker accepts completion callbacks on:
+
+`POST /v1/allocations/{id}/complete`
+
+Supported payload forms:
+
+- `{ "state": "completed" }` (default state)
+- `{ "state": "completed" | "failed" | "canceled", "reason": "...", "error": "..." }`
+- `{ "state": "expired" }`
+- `{ "state": "quarantined" }`
+
+Duplicate callbacks for the same terminal state are idempotent and do not re-release scheduler capacity.
+
+### Orphan cleanup and quarantine
+
+Stale active allocations are reclaimed during periodic sweep.
+
+```yaml
+broker:
+  orphanCleanup:
+    enabled: false
+    quarantineTTL: 15m
+```
+
+- `enabled: false` (default): active stale allocations move directly to `expired`.
+- `enabled: true`: active stale allocations move to `quarantined` for `quarantineTTL` (or immediately when `0`), then to `expired`.
+
 ## Project Layout
 
 - `cmd/broker`: broker entrypoint

--- a/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
+++ b/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
@@ -15,9 +15,11 @@ data:
     broker:
       defaultPool: {{ .Values.config.broker.defaultPool }}
       defaultJobTimeout: {{ .Values.config.broker.defaultJobTimeout }}
+      orphanCleanup:
+        enabled: {{ .Values.config.broker.orphanCleanup.enabled }}
+        quarantineTTL: {{ .Values.config.broker.orphanCleanup.quarantineTTL }}
       allowUnauthenticated: {{ .Values.config.allowUnauthenticated }}
       api:
         oidcAudience: {{ .Values.config.broker.api.oidcAudience }}
     pools:
 {{ toYaml .Values.config.pools | indent 6 }}
-

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -51,6 +51,9 @@ config:
   broker:
     defaultPool: full
     defaultJobTimeout: 15m
+    orphanCleanup:
+      enabled: false
+      quarantineTTL: 15m
     api:
       oidcAudience: uecb-broker
   pools:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -47,7 +47,7 @@ High allocation failure rate means requests are being rejected or backend provis
 
 Saturated capacity means the scheduler has few or no healthy slots available for a pool/backend. Check `maxRunners`, runner cleanup, and whether completed jobs are leaving allocations in `ready` or `reserved`.
 
-Stuck queue depth means allocations are not moving to terminal states. Check expiration sweeps, backend cancellation behavior, and runner completion callbacks in the consuming environment.
+Stuck queue depth means allocations are not moving to terminal states. Check expiration sweeps, backend cancellation behavior, explicit completion callbacks, and quarantine transitions (`quarantined` -> `expired`).
 
 ## Example SLOs
 

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -111,6 +111,36 @@ func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasSuffix(path, "/complete") {
+		id := strings.TrimSuffix(path, "/complete")
+		id = strings.TrimSuffix(id, "/")
+		if r.Method != http.MethodPost {
+			s.writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+			return
+		}
+
+		completion, err := decodeCompletionRequest(r.Body)
+		if err != nil {
+			s.writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		status, ok, err := s.service.Complete(r.Context(), id, completion)
+		if err != nil {
+			if errors.Is(err, ErrAllocationNotFound) {
+				s.writeError(w, http.StatusNotFound, err)
+				return
+			}
+			s.writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		if !ok {
+			s.writeError(w, http.StatusNotFound, errors.New("allocation not found"))
+			return
+		}
+		s.writeJSON(w, http.StatusOK, status)
+		return
+	}
+
 	if r.Method != http.MethodGet {
 		s.writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
 		return

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -141,3 +141,66 @@ func TestHandleAllocationsRejectsMissingExternalBackendSecret(t *testing.T) {
 		t.Fatalf("expected secret error, got %s", recorder.Body.String())
 	}
 }
+
+func TestHandleAllocationCompleteMarksAllocationCompleted(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	server := newTestServer(t, service)
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocation failed: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations/"+allocation.ID+"/complete", bytes.NewBufferString(`{"state":"completed","reason":"job done"}`))
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	var completed model.AllocationStatus
+	if err := json.NewDecoder(recorder.Body).Decode(&completed); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if completed.State != model.StateCompleted {
+		t.Fatalf("expected completed state, got %q", completed.State)
+	}
+}
+
+func TestHandleAllocationCompleteReturnsNotFoundWhenAllocationMissing(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	server := newTestServer(t, service)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations/missing-id/complete", bytes.NewBufferString(`{"state":"completed"}`))
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestHandleAllocationCompleteRejectsUnknownState(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	server := newTestServer(t, service)
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocation failed: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations/"+allocation.ID+"/complete", bytes.NewBufferString(`{"state":"invalid-state"}`))
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -74,3 +74,15 @@ func decodeAllocationRequest(reader io.Reader) (model.AllocationRequest, error) 
 		ExcludedCapabilities: append([]string(nil), request.ExcludedCapabilities...),
 	}, nil
 }
+
+func decodeCompletionRequest(reader io.Reader) (completionRequest, error) {
+	var request completionRequest
+	decoder := json.NewDecoder(reader)
+	if err := decoder.Decode(&request); err != nil {
+		return completionRequest{}, fmt.Errorf("invalid completion request: %w", err)
+	}
+	request.State = strings.TrimSpace(request.State)
+	request.Reason = strings.TrimSpace(request.Reason)
+	request.Error = strings.TrimSpace(request.Error)
+	return request, nil
+}

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -97,3 +97,36 @@ func TestDecodeAllocationRequestCopiesCapabilities(t *testing.T) {
 		t.Fatalf("unexpected excluded capabilities: %#v", request.ExcludedCapabilities)
 	}
 }
+
+func TestDecodeCompletionRequestDefaultsToCompleted(t *testing.T) {
+	request, err := decodeCompletionRequest(bytes.NewReader([]byte(`{"reason":"already finished"}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.State != "" {
+		t.Fatalf("expected empty state, got %q", request.State)
+	}
+}
+
+func TestDecodeCompletionRequestParsesFailedError(t *testing.T) {
+	request, err := decodeCompletionRequest(bytes.NewReader([]byte(`{"state":"failed","error":"boom","reason":"unused"}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.Error != "boom" {
+		t.Fatalf("expected error, got %q", request.Error)
+	}
+}
+
+func TestDecodeCompletionRequestTrimsWhitespace(t *testing.T) {
+	request, err := decodeCompletionRequest(bytes.NewReader([]byte(`{"state":" completed ","reason":" job done "}`)))
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if request.State != "completed" {
+		t.Fatalf("expected trimmed state, got %q", request.State)
+	}
+	if request.Reason != "job done" {
+		t.Fatalf("expected trimmed reason, got %q", request.Reason)
+	}
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
@@ -16,6 +18,9 @@ import (
 
 var ErrUnknownPool = errors.New("pool is not configured")
 var ErrNoMatchingBackendCapabilities = errors.New("no backend matches the requested capabilities")
+var ErrAllocationNotFound = errors.New("allocation not found")
+var ErrAllocationAlreadyCompleted = errors.New("allocation already in terminal state")
+var ErrInvalidCompletionState = errors.New("invalid completion state")
 
 type Service struct {
 	cfg       model.BrokerConfig
@@ -125,7 +130,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 
 	backendImpl, ok := s.registry.Get(selected)
 	if !ok {
-		s.release(pool, selected, allocation)
+		s.release(context.Background(), pool, selected, allocation)
 		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), "backend not registered")
 		return model.AllocationStatus{}, fmt.Errorf("backend implementation missing: %s", selected)
 	}
@@ -136,7 +141,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	s.observer.ObserveLaunchLatency(pool.Name, selected, launchLatency)
 	s.observer.ObserveRegistrationLatency(pool.Name, selected, launchLatency)
 	if err != nil {
-		s.release(pool, selected, allocation)
+		s.release(context.Background(), pool, selected, allocation)
 		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), err.Error())
 		logAllocationEvent(ctx, "allocation_failed", map[string]string{
 			"allocation_id": allocation.ID,
@@ -178,30 +183,115 @@ func (s *Service) Cancel(id string) (model.AllocationStatus, bool) {
 		return model.AllocationStatus{}, false
 	}
 	if pool, err := s.resolvePool(status.Pool); err == nil {
-		s.release(pool, status.SelectedBackend, status)
+		s.release(context.Background(), pool, status.SelectedBackend, status)
 	}
 	s.observeState()
 	return status, true
 }
 
+type completionRequest struct {
+	State  string `json:"state"`
+	Error  string `json:"error"`
+	Reason string `json:"reason"`
+}
+
+func (s *Service) Complete(ctx context.Context, id string, request completionRequest) (model.AllocationStatus, bool, error) {
+	status, ok := s.store.Get(id)
+	if !ok {
+		return model.AllocationStatus{}, false, nil
+	}
+
+	targetState, message, err := parseCompletionState(request)
+	if err != nil {
+		return model.AllocationStatus{}, false, err
+	}
+	if strings.TrimSpace(message) == "" {
+		message = defaultCompletionMessage(targetState)
+	}
+	if isTerminalAllocationState(status.State) {
+		if status.State == targetState {
+			return status, true, nil
+		}
+		return status, true, fmt.Errorf("%w: current=%s requested=%s", ErrAllocationAlreadyCompleted, status.State, targetState)
+	}
+	if status.State == targetState {
+		return status, true, nil
+	}
+
+	updated, ok := s.store.MarkState(id, targetState, s.now(), message)
+	if !ok {
+		return model.AllocationStatus{}, false, nil
+	}
+	if isActiveAllocationState(status.State) {
+		if pool, err := s.resolvePool(status.Pool); err == nil {
+			s.release(ctx, pool, status.SelectedBackend, status)
+		}
+	}
+	logAllocationEvent(ctx, completionEventName(targetState), map[string]string{
+		"allocation_id": allocationIDLabel(status.ID),
+		"pool":          string(status.Pool),
+		"backend":       string(status.SelectedBackend),
+		"state":         string(targetState),
+		"error":         message,
+	})
+	s.observeState()
+	return updated, true, nil
+}
+
 func (s *Service) SweepExpired(now time.Time) int {
-	expired := 0
+	updated := 0
 	for _, status := range s.store.List() {
-		if status.State != model.StateReady && status.State != model.StateReserved {
+		if isActiveAllocationState(status.State) {
+			if status.ExpiresAt.After(now) {
+				continue
+			}
+
+			nextState := model.StateExpired
+			nextMessage := "allocation expired"
+			nextExpiresAt := now
+			if s.cfg.Broker.OrphanCleanup.Enabled {
+				nextState = model.StateQuarantined
+				nextMessage = "allocation quarantined"
+				nextExpiresAt = now
+				if s.cfg.Broker.OrphanCleanup.QuarantineTTL > 0 {
+					nextExpiresAt = now.Add(s.cfg.Broker.OrphanCleanup.QuarantineTTL)
+				}
+			}
+			if _, ok := s.store.MarkState(status.ID, nextState, nextExpiresAt, nextMessage); ok {
+				if pool, err := s.resolvePool(status.Pool); err == nil {
+					s.release(context.Background(), pool, status.SelectedBackend, status)
+				}
+				logAllocationEvent(context.Background(), "allocation_"+string(nextState), map[string]string{
+					"allocation_id": allocationIDLabel(status.ID),
+					"pool":          string(status.Pool),
+					"backend":       string(status.SelectedBackend),
+				})
+				updated++
+			}
 			continue
 		}
+
+		if status.State != model.StateQuarantined {
+			continue
+		}
+
 		if status.ExpiresAt.After(now) {
 			continue
 		}
-		if _, ok := s.store.MarkState(status.ID, model.StateExpired, now, "allocation expired"); ok {
+		if _, ok := s.store.MarkState(status.ID, model.StateExpired, now, "allocation quarantine expired"); ok {
 			if pool, err := s.resolvePool(status.Pool); err == nil {
-				s.release(pool, status.SelectedBackend, status)
+				s.release(context.Background(), pool, status.SelectedBackend, status)
 			}
-			expired++
+			logAllocationEvent(context.Background(), "allocation_expired", map[string]string{
+				"allocation_id": allocationIDLabel(status.ID),
+				"pool":          string(status.Pool),
+				"backend":       string(status.SelectedBackend),
+			})
+			updated++
 		}
 	}
 	s.observeState()
-	return expired
+	return updated
 }
 
 func (s *Service) observeState() {
@@ -256,14 +346,109 @@ func (s *Service) reserve(pool model.PoolConfig, request model.AllocationRequest
 	return s.schedulerForPool(pool).Reserve(pool, request)
 }
 
-func (s *Service) release(pool model.PoolConfig, backend model.BackendName, allocation model.AllocationStatus) {
+func (s *Service) release(ctx context.Context, pool model.PoolConfig, backend model.BackendName, allocation model.AllocationStatus) {
 	if pool.FairShare.Enabled {
 		if s.fairShare != nil {
 			s.fairShare.Release(pool.Name, backend, allocation)
 		}
+		s.cleanupAllocation(ctx, allocation)
 		return
 	}
 	s.schedulerForPool(pool).Release(pool.Name, backend, allocation)
+	s.cleanupAllocation(ctx, allocation)
+}
+
+func (s *Service) cleanupAllocation(ctx context.Context, allocation model.AllocationStatus) {
+	backendImpl, ok := s.registry.Get(allocation.SelectedBackend)
+	if !ok {
+		return
+	}
+	cleanupBackend, ok := backendImpl.(backend.CleanupBackend)
+	if !ok {
+		return
+	}
+	if err := cleanupBackend.Cleanup(ctx, allocation); err != nil {
+		logAllocationEvent(ctx, "allocation_cleanup_failed", map[string]string{
+			"allocation_id": allocationIDLabel(allocation.ID),
+			"pool":          string(allocation.Pool),
+			"backend":       string(allocation.SelectedBackend),
+			"error":         err.Error(),
+		})
+		log.Printf("allocation cleanup failed for %s: %v", allocation.ID, err)
+	}
+}
+
+func allocationIDLabel(id string) string {
+	return strings.TrimSpace(id)
+}
+
+func isActiveAllocationState(state model.AllocationState) bool {
+	return state == model.StateReady || state == model.StateReserved
+}
+
+func isTerminalAllocationState(state model.AllocationState) bool {
+	switch state {
+	case model.StateCompleted, model.StateFailed, model.StateCanceled, model.StateExpired, model.StateQuarantined:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseCompletionState(request completionRequest) (model.AllocationState, string, error) {
+	state := strings.TrimSpace(strings.ToLower(request.State))
+	if state == "" {
+		return model.StateCompleted, "", nil
+	}
+
+	switch state {
+	case "complete", "completed", "success", "succeeded":
+		return model.StateCompleted, request.Reason, nil
+	case "failed", "failure", "error":
+		return model.StateFailed, request.Error, nil
+	case "canceled", "cancelled", "cancel":
+		return model.StateCanceled, request.Reason, nil
+	case "expired":
+		return model.StateExpired, request.Reason, nil
+	case "quarantined", "quarantine":
+		return model.StateQuarantined, request.Reason, nil
+	default:
+		return "", "", fmt.Errorf("%w: %q", ErrInvalidCompletionState, request.State)
+	}
+}
+
+func defaultCompletionMessage(state model.AllocationState) string {
+	switch state {
+	case model.StateCompleted:
+		return "allocation completed"
+	case model.StateFailed:
+		return "allocation failed"
+	case model.StateCanceled:
+		return "allocation canceled"
+	case model.StateExpired:
+		return "allocation expired"
+	case model.StateQuarantined:
+		return "allocation quarantined"
+	default:
+		return ""
+	}
+}
+
+func completionEventName(state model.AllocationState) string {
+	switch state {
+	case model.StateCompleted:
+		return "allocation_completed"
+	case model.StateFailed:
+		return "allocation_failed"
+	case model.StateCanceled:
+		return "allocation_canceled"
+	case model.StateExpired:
+		return "allocation_expired"
+	case model.StateQuarantined:
+		return "allocation_quarantined"
+	default:
+		return "allocation_updated"
+	}
 }
 
 func validateSchedulers(pools []model.PoolConfig, registry *scheduler.Registry) error {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -42,6 +42,22 @@ func (b testBackend) Provision(_ context.Context, request model.AllocationReques
 	}, nil
 }
 
+type testCleanupBackend struct {
+	testBackend
+	failCleanup bool
+	cleanupSeen *bool
+}
+
+func (b *testCleanupBackend) Cleanup(_ context.Context, _ model.AllocationStatus) error {
+	if b.cleanupSeen != nil {
+		*b.cleanupSeen = true
+	}
+	if !b.failCleanup {
+		return nil
+	}
+	return errors.New("cleanup failed")
+}
+
 func newService() *Service {
 	return newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {
@@ -337,6 +353,98 @@ func TestCancelReleasesCapacity(t *testing.T) {
 	}
 }
 
+func TestCompleteMarksAllocationCompletedAndReleasesCapacity(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolFull {
+			return
+		}
+		arcCfg := pool.Backends[model.BackendARC]
+		arcCfg.MaxRunners = 1
+		pool.Backends[model.BackendARC] = arcCfg
+	})
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	completed, ok, err := service.Complete(context.Background(), allocation.ID, completionRequest{State: "completed"})
+	if err != nil {
+		t.Fatalf("first completion failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected first completion to succeed")
+	}
+	if completed.State != model.StateCompleted {
+		t.Fatalf("expected completed state, got %s", completed.State)
+	}
+
+	// Duplicate completion must remain idempotent and not break capacity accounting.
+	duplicate, ok, err := service.Complete(context.Background(), allocation.ID, completionRequest{State: "completed"})
+	if err != nil {
+		t.Fatalf("duplicate completion failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected duplicate completion to return true")
+	}
+	if duplicate.State != model.StateCompleted {
+		t.Fatalf("expected duplicate completion state to remain completed, got %s", duplicate.State)
+	}
+
+	if _, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 5 * time.Minute,
+	}); err != nil {
+		t.Fatalf("expected capacity to be reusable after completion callback: %v", err)
+	}
+}
+
+func TestCompleteRejectsUnknownState(t *testing.T) {
+	service := newService()
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	_, _, completeErr := service.Complete(context.Background(), allocation.ID, completionRequest{State: "not-a-state"})
+	if completeErr == nil {
+		t.Fatal("expected unknown completion state to fail")
+	}
+	if !errors.Is(completeErr, ErrInvalidCompletionState) {
+		t.Fatalf("expected ErrInvalidCompletionState, got: %v", completeErr)
+	}
+}
+
+func TestCompleteReturnsTerminalErrorWhenAlreadyTerminal(t *testing.T) {
+	service := newService()
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	failed, _, err := service.Complete(context.Background(), allocation.ID, completionRequest{State: "failed"})
+	if err != nil {
+		t.Fatalf("failed completion failed: %v", err)
+	}
+	if failed.State != model.StateFailed {
+		t.Fatalf("expected failed state, got %s", failed.State)
+	}
+
+	if _, _, err = service.Complete(context.Background(), allocation.ID, completionRequest{State: "completed"}); err == nil || !errors.Is(err, ErrAllocationAlreadyCompleted) {
+		t.Fatalf("expected terminal state completion error, got %v", err)
+	}
+}
+
 func TestSweepExpiredMarksReadyAllocationsExpired(t *testing.T) {
 	service := newService()
 	service.now = func() time.Time { return time.Unix(1000, 0) }
@@ -361,6 +469,115 @@ func TestSweepExpiredMarksReadyAllocationsExpired(t *testing.T) {
 
 	if updated.State != model.StateExpired {
 		t.Fatalf("expected expired state, got %s", updated.State)
+	}
+}
+
+func TestSweepExpiredMarksReadyAllocationsQuarantinedWhenEnabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Broker.OrphanCleanup.Enabled = true
+	cfg.Broker.OrphanCleanup.QuarantineTTL = 10 * time.Second
+
+	service := NewService(
+		cfg,
+		backend.NewRegistry(
+			testBackend{name: model.BackendARC},
+			testBackend{name: model.BackendCodeBuild},
+			testBackend{name: model.BackendLambda},
+			testBackend{name: model.BackendCloudRun},
+			testBackend{name: model.BackendAzureFunctions},
+		),
+		nil,
+	)
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	swept := service.SweepExpired(time.Unix(1015, 0))
+	if swept != 1 {
+		t.Fatalf("expected 1 allocation to be swept, got %d", swept)
+	}
+
+	updated, ok := service.Get(allocation.ID)
+	if !ok {
+		t.Fatal("allocation disappeared after sweep")
+	}
+	if updated.State != model.StateQuarantined {
+		t.Fatalf("expected quarantined state, got %s", updated.State)
+	}
+	expectedExpiry := time.Unix(1015, 0).Add(10 * time.Second)
+	if !updated.ExpiresAt.Equal(expectedExpiry) {
+		t.Fatalf("expected quarantine expiry %s, got %s", expectedExpiry, updated.ExpiresAt)
+	}
+
+	service.SweepExpired(time.Unix(1025, 0))
+	if updated, ok = service.Get(allocation.ID); !ok {
+		t.Fatal("allocation disappeared after quarantine expiry")
+	}
+	if updated.State != model.StateExpired {
+		t.Fatalf("expected expiry to clear quarantine, got %s", updated.State)
+	}
+}
+
+func TestCompleteReturnsNotFoundForMissingAllocation(t *testing.T) {
+	restartService := newService()
+	service := newService()
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+	if _, ok, err := restartService.Complete(context.Background(), allocation.ID, completionRequest{State: "completed"}); err != nil || ok {
+		t.Fatalf("expected missing allocation on restart-like service, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCompleteHandlesCleanupFailureWithoutBlocking(t *testing.T) {
+	cfg := config.Default()
+	arcCfg := cfg.Pools[0].Backends[model.BackendARC]
+	arcCfg.MaxRunners = 1
+	cfg.Pools[0].Backends[model.BackendARC] = arcCfg
+	cleanupCalled := false
+
+	service := NewService(
+		cfg,
+		backend.NewRegistry(
+			&testCleanupBackend{
+				testBackend: testBackend{name: model.BackendARC},
+				failCleanup: true,
+				cleanupSeen: &cleanupCalled,
+			},
+		),
+		nil,
+	)
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolFull,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+
+	updated, ok, err := service.Complete(context.Background(), allocation.ID, completionRequest{State: "failed", Error: "runner crashed"})
+	if err != nil {
+		t.Fatalf("completion failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected completion to return true")
+	}
+	if updated.State != model.StateFailed {
+		t.Fatalf("expected failed state, got %s", updated.State)
+	}
+	if !cleanupCalled {
+		t.Fatal("expected cleanup hook to run even with failures")
 	}
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -21,6 +21,10 @@ type Backend interface {
 	Provision(ctx context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (ProvisionedRunner, error)
 }
 
+type CleanupBackend interface {
+	Cleanup(ctx context.Context, status model.AllocationStatus) error
+}
+
 type Registry struct {
 	backends map[model.BackendName]Backend
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -24,6 +24,13 @@ func Default() model.BrokerConfig {
 		Broker: model.BrokerRuntimeConfig{
 			DefaultPool:       model.PoolFull,
 			DefaultJobTimeout: 15 * time.Minute,
+			OrphanCleanup: struct {
+				Enabled       bool          `yaml:"enabled" json:"enabled"`
+				QuarantineTTL time.Duration `yaml:"quarantineTTL" json:"quarantineTTL"`
+			}{
+				Enabled:       false,
+				QuarantineTTL: 15 * time.Minute,
+			},
 			API: model.BrokerAPIConfig{
 				OIDCAudience: "uecb-broker",
 			},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -29,11 +29,13 @@ const (
 type AllocationState string
 
 const (
-	StateReserved AllocationState = "reserved"
-	StateReady    AllocationState = "ready"
-	StateCanceled AllocationState = "canceled"
-	StateExpired  AllocationState = "expired"
-	StateFailed   AllocationState = "failed"
+	StateReserved    AllocationState = "reserved"
+	StateReady       AllocationState = "ready"
+	StateCanceled    AllocationState = "canceled"
+	StateExpired     AllocationState = "expired"
+	StateFailed      AllocationState = "failed"
+	StateCompleted   AllocationState = "completed"
+	StateQuarantined AllocationState = "quarantined"
 )
 
 type PriorityClass string
@@ -66,10 +68,14 @@ type BrokerAPIConfig struct {
 }
 
 type BrokerRuntimeConfig struct {
-	DefaultPool          PoolName        `yaml:"defaultPool" json:"defaultPool"`
-	DefaultJobTimeout    time.Duration   `yaml:"defaultJobTimeout" json:"defaultJobTimeout"`
-	AllowUnauthenticated bool            `yaml:"allowUnauthenticated" json:"allowUnauthenticated"`
-	API                  BrokerAPIConfig `yaml:"api" json:"api"`
+	DefaultPool          PoolName      `yaml:"defaultPool" json:"defaultPool"`
+	DefaultJobTimeout    time.Duration `yaml:"defaultJobTimeout" json:"defaultJobTimeout"`
+	AllowUnauthenticated bool          `yaml:"allowUnauthenticated" json:"allowUnauthenticated"`
+	OrphanCleanup        struct {
+		Enabled       bool          `yaml:"enabled" json:"enabled"`
+		QuarantineTTL time.Duration `yaml:"quarantineTTL" json:"quarantineTTL"`
+	} `yaml:"orphanCleanup" json:"orphanCleanup"`
+	API BrokerAPIConfig `yaml:"api" json:"api"`
 }
 
 type BackendConfig struct {

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -53,7 +53,7 @@ func (m *Memory) MarkState(id string, state model.AllocationState, now time.Time
 	if message != "" {
 		status.Error = message
 	}
-	if state == model.StateExpired {
+	if state == model.StateExpired || state == model.StateQuarantined {
 		status.ExpiresAt = now
 	}
 


### PR DESCRIPTION
## Summary
- Add allocation completion endpoint with explicit terminal state handling.
- Implement orphan cleanup behavior with optional quarantine + TTL-backed expiration.
- Route complete callbacks through idempotent service semantics with duplicate handling.
- Add backend cleanup hook interface for non-blocking resource cleanup.
- Update default config and Helm chart values/config map for orphanCleanup.
- Extend API and unit test coverage for completion parsing, cleanup, quarantine sweep, and restart/no-op cases.

Closes #6