### PR TITLE
Implement warm pool scheduler and launch mode for issue #5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,22 @@ jobs:
           test -f actions/allocate-runner/action.yml
           test -f examples/gitops/kustomize/base/kustomization.yaml
 
+  warm-pool-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Warm pool regression tests
+        run: |
+          go test ./internal/api \
+            -run "TestAllocatePrefersWarmAllocationOverColdLaunch|TestReconcileWarmPoolsCreatesWarmAllocation|TestReconcileWarmPoolsRecyclesExpiredWarmAllocation" \
+            -count=1
+
+          go test ./internal/backend/externaldispatch \
+            -run "TestProvisionPassesLaunchModeFromAllocationMetadata" \
+            -count=1
+

--- a/README.md
+++ b/README.md
@@ -254,6 +254,42 @@ pools:
 
 Rollback is just a config change: set `scheduler` back to `round-robin` for the pool and redeploy. Leaving `weight` values in place is safe because the default scheduler ignores them.
 
+## Warm Capacity
+
+Backend pools can maintain pre-initialized warm runners to reduce cold-start latency for external backends.
+
+Warm behavior is configured per backend:
+
+- `warmMin`: minimum number of warm allocations to keep for the backend.
+- `warmMax`: maximum number of warm allocations to keep for the backend.
+- `warmTTL`: how long a warm allocation stays idle before recycle.
+
+Warm allocations are created only for external backends that are enabled and healthy. `arc` and `azure-vm` are not included because they are not external dispatchers and are expected to launch quickly.
+
+```yaml
+pools:
+  - name: lite
+    backends:
+      codebuild:
+        enabled: true
+        maxRunners: 3
+        weight: 1
+        warmMin: 1
+        warmMax: 2
+        warmTTL: 10m
+        secretRef: uecb-codebuild
+```
+
+When warm capacity exists:
+
+- the broker prefers an available warm slot before provisioning cold;
+- idle warm runners are recycled on TTL expiry or capacity policy changes;
+- warm capacity may consume active runner quota while in warm state.
+
+If a warm slot is unavailable or expired, the broker falls back to cold launch as before.
+
+Use warm pools where external cold-start latency dominates.
+
 ### Priority And Fair-Share Scheduling
 
 Pools can opt into tenant-aware dispatch independently of the backend scheduler with `fairShare.enabled`.

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -113,6 +113,9 @@ config:
           enabled: false
           healthy: true
           maxRunners: 3
+          # warmMin: 0
+          # warmMax: 0
+          # warmTTL: 15m
           weight: 1
           maxJobDuration: 14m
           capabilities:
@@ -123,6 +126,9 @@ config:
           enabled: false
           healthy: true
           maxRunners: 3
+          # warmMin: 0
+          # warmMax: 0
+          # warmTTL: 15m
           weight: 1
           maxJobDuration: 14m
           capabilities:

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -62,6 +62,14 @@ func main() {
 		}
 	}()
 
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			service.ReconcileWarmPools()
+		}
+	}()
+
 	addr := os.Getenv("UECB_HTTP_ADDR")
 	if addr == "" {
 		addr = ":8080"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,18 @@
 - The public Azure Functions launcher uses an HTTP dispatch endpoint only for admission and status. Actual runner execution happens on a queue-triggered function inside the same container so the HTTP trigger does not have to stay open for the whole job.
 - Each runner handles one job and exits.
 
+## Warm Capacity
+
+Each pool backend may define a warm policy:
+
+- `warmMin`: minimum warm instances to keep reserved.
+- `warmMax`: maximum warm instances allowed.
+- `warmTTL`: maximum idle lifetime for a warm allocation.
+
+The broker keeps warm allocations in the background when enabled and recycles them on TTL expiry or policy violations. Allocation requests consume warm capacity first when available, then fallback to cold launch.
+
+Warm capacity currently applies only to external dispatch backends and intentionally excludes `arc` and `azure-vm`.
+
 ## Pools
 
 - `full`: full-capability jobs, ARC only in v1

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,7 +27,7 @@ Core metrics:
 - `uecb_http_requests_total{route,method,status}`: broker HTTP request count.
 - `uecb_allocations_total{pool,backend,result}`: allocation attempts and success or failure results.
 - `uecb_allocation_latency_seconds{pool,backend,result}`: end-to-end broker allocation latency.
-- `uecb_launch_latency_seconds{pool,backend}`: backend launch handoff latency.
+- `uecb_launch_latency_seconds{pool,backend,launch_mode}`: backend launch handoff latency by launch mode (`cold` or `warm`).
 - `uecb_registration_latency_seconds{pool,backend}`: time until the broker has a provisioned runner label.
 - `uecb_queue_depth{pool,state}`: current allocations by state.
 - `uecb_capacity_utilization_ratio{pool,backend}`: active allocation count divided by configured backend capacity.
@@ -41,7 +41,7 @@ The observability pack does not change scheduler selection, capacity reservation
 
 ## Failure Modes
 
-High allocation latency usually means the broker can accept requests but a backend is slow to launch or register a runner. Compare `uecb_allocation_latency_seconds` with `uecb_launch_latency_seconds` and `uecb_registration_latency_seconds` by backend.
+High allocation latency usually means the broker can accept requests but a backend is slow to launch or register a runner. Compare `uecb_allocation_latency_seconds` with `uecb_launch_latency_seconds` by backend and launch mode, and `uecb_registration_latency_seconds`.
 
 High allocation failure rate means requests are being rejected or backend provisioning is failing. Check broker logs by `correlation_id`, then inspect the selected backend controller logs for the same ID.
 

--- a/examples/gitops/kustomize/base/configmap.yaml
+++ b/examples/gitops/kustomize/base/configmap.yaml
@@ -58,6 +58,9 @@ data:
             enabled: false
             healthy: true
             maxRunners: 3
+            # warmMin: 0
+            # warmMax: 0
+            # warmTTL: 15m
             weight: 1
             maxJobDuration: 14m
             capabilities: [docker, region:aws-us-east-1]

--- a/internal/api/observability.go
+++ b/internal/api/observability.go
@@ -23,7 +23,7 @@ const correlationContextKey contextKey = correlationIDKey
 type Observer interface {
 	ObserveAllocationStart(model.PoolName)
 	ObserveAllocationResult(model.PoolName, model.BackendName, string, time.Duration)
-	ObserveLaunchLatency(model.PoolName, model.BackendName, time.Duration)
+	ObserveLaunchLatency(model.PoolName, model.BackendName, string, time.Duration)
 	ObserveRegistrationLatency(model.PoolName, model.BackendName, time.Duration)
 	ObserveActiveAllocations([]model.AllocationStatus)
 	ObserveCapacity(model.BrokerConfig, []model.AllocationStatus)
@@ -34,7 +34,7 @@ type noopObserver struct{}
 func (noopObserver) ObserveAllocationStart(model.PoolName) {}
 func (noopObserver) ObserveAllocationResult(model.PoolName, model.BackendName, string, time.Duration) {
 }
-func (noopObserver) ObserveLaunchLatency(model.PoolName, model.BackendName, time.Duration) {}
+func (noopObserver) ObserveLaunchLatency(model.PoolName, model.BackendName, string, time.Duration) {}
 func (noopObserver) ObserveRegistrationLatency(model.PoolName, model.BackendName, time.Duration) {
 }
 func (noopObserver) ObserveActiveAllocations([]model.AllocationStatus)            {}
@@ -64,7 +64,7 @@ func NewPrometheusObserver(registerer prometheus.Registerer) *PrometheusObserver
 			Name:    "uecb_launch_latency_seconds",
 			Help:    "Backend launch latency for a selected ephemeral runner.",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 90},
-		}, []string{"pool", "backend"}),
+		}, []string{"pool", "backend", "launch_mode"}),
 		registrationLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "uecb_registration_latency_seconds",
 			Help:    "Observed latency until a provisioned runner registration response is available to the broker.",
@@ -115,8 +115,8 @@ func (o *PrometheusObserver) ObserveAllocationResult(pool model.PoolName, backen
 	o.allocationLatency.WithLabelValues(string(pool), string(backend), result).Observe(latency.Seconds())
 }
 
-func (o *PrometheusObserver) ObserveLaunchLatency(pool model.PoolName, backend model.BackendName, latency time.Duration) {
-	o.launchLatency.WithLabelValues(string(pool), string(backend)).Observe(latency.Seconds())
+func (o *PrometheusObserver) ObserveLaunchLatency(pool model.PoolName, backend model.BackendName, launchMode string, latency time.Duration) {
+	o.launchLatency.WithLabelValues(string(pool), string(backend), launchMode).Observe(latency.Seconds())
 }
 
 func (o *PrometheusObserver) ObserveRegistrationLatency(pool model.PoolName, backend model.BackendName, latency time.Duration) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
@@ -22,6 +24,12 @@ var ErrAllocationNotFound = errors.New("allocation not found")
 var ErrAllocationAlreadyCompleted = errors.New("allocation already in terminal state")
 var ErrInvalidCompletionState = errors.New("invalid completion state")
 
+const (
+	defaultWarmTTL = 15 * time.Minute
+	launchModeCold = "cold"
+	launchModeWarm = "warm"
+)
+
 type Service struct {
 	cfg       model.BrokerConfig
 	registry  *backend.Registry
@@ -29,6 +37,7 @@ type Service struct {
 	fairShare *scheduler.PriorityFairShare
 	store     *store.Memory
 	observer  Observer
+	warmMu    sync.Mutex
 	initErr   error
 	health    func(context.Context) error
 	now       func() time.Time
@@ -64,6 +73,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	started := s.now()
 	resultPool := request.Pool
 	var resultBackend model.BackendName
+	launchMode := launchModeCold
 	result := "failure"
 	defer func() {
 		s.observer.ObserveAllocationResult(resultPool, resultBackend, result, s.now().Sub(started))
@@ -121,6 +131,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		Tenant:          request.Tenant,
 		PriorityClass:   request.PriorityClass,
 		RequestedLabels: append([]string(nil), request.Labels...),
+		Metadata:        map[string]string{backend.MetadataLaunchModeKey: launchModeCold},
 		ExpiresAt:       s.now().Add(timeout),
 		State:           model.StateReserved,
 	}
@@ -134,10 +145,38 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		return model.AllocationStatus{}, fmt.Errorf("backend implementation missing: %s", selected)
 	}
 
+	if warmAllocation, ok := s.consumeWarmAllocation(ctx, pool, selected, allocation); ok {
+		s.schedulerForPool(pool).Release(pool.Name, selected, allocation)
+		launchMode = launchModeWarm
+		warmAllocation.State = model.StateReady
+		warmAllocation.CorrelationID = allocation.CorrelationID
+		warmAllocation.Tenant = request.Tenant
+		warmAllocation.PriorityClass = request.PriorityClass
+		warmAllocation.RequestedLabels = append([]string(nil), request.Labels...)
+		warmAllocation.ExpiresAt = allocation.ExpiresAt
+		warmAllocation.Metadata = withLaunchModeMetadata(
+			backend.WithCapabilitiesMetadata(pool.Backends[selected], warmAllocation.Metadata),
+			launchMode,
+		)
+		s.store.Save(warmAllocation)
+		launchLatency := time.Duration(0)
+		s.observer.ObserveLaunchLatency(pool.Name, selected, launchMode, launchLatency)
+		s.observer.ObserveRegistrationLatency(pool.Name, selected, launchLatency)
+		result = "success"
+		allocation = warmAllocation
+		logAllocationEvent(ctx, "allocation_ready", map[string]string{
+			"allocation_id": allocation.ID,
+			"pool":          string(pool.Name),
+			"backend":       string(selected),
+			"launch_mode":   launchMode,
+		})
+		return allocation, nil
+	}
+
 	launchStarted := s.now()
 	provisioned, err := backendImpl.Provision(ctx, request, allocation)
 	launchLatency := s.now().Sub(launchStarted)
-	s.observer.ObserveLaunchLatency(pool.Name, selected, launchLatency)
+	s.observer.ObserveLaunchLatency(pool.Name, selected, launchMode, launchLatency)
 	s.observer.ObserveRegistrationLatency(pool.Name, selected, launchLatency)
 	if err != nil {
 		s.release(context.Background(), pool, selected, allocation)
@@ -152,7 +191,10 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	}
 
 	allocation.RunnerLabel = provisioned.RunnerLabel
-	allocation.Metadata = backend.WithCapabilitiesMetadata(pool.Backends[selected], provisioned.Metadata)
+	allocation.Metadata = withLaunchModeMetadata(
+		backend.WithCapabilitiesMetadata(pool.Backends[selected], provisioned.Metadata),
+		launchMode,
+	)
 	allocation.State = model.StateReady
 	s.store.Save(allocation)
 	result = "success"
@@ -160,9 +202,21 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		"allocation_id": allocation.ID,
 		"pool":          string(pool.Name),
 		"backend":       string(selected),
+		"launch_mode":   launchMode,
 	})
 
 	return allocation, nil
+}
+
+func (s *Service) ReconcileWarmPools() {
+	s.warmMu.Lock()
+	defer s.warmMu.Unlock()
+
+	now := s.now()
+	statuses := s.store.List()
+	for _, pool := range s.cfg.Pools {
+		s.reconcileWarmForPool(pool, statuses, now)
+	}
 }
 
 func (s *Service) Health(ctx context.Context) error {
@@ -297,6 +351,303 @@ func (s *Service) observeState() {
 	statuses := s.store.List()
 	s.observer.ObserveActiveAllocations(statuses)
 	s.observer.ObserveCapacity(s.cfg, statuses)
+}
+
+func (s *Service) consumeWarmAllocation(ctx context.Context, pool model.PoolConfig, backendName model.BackendName, request model.AllocationStatus) (model.AllocationStatus, bool) {
+	cfg, ok := pool.Backends[backendName]
+	if !ok || !cfg.Enabled || !cfg.Healthy || !isWarmProvisionableBackend(backendName) {
+		return model.AllocationStatus{}, false
+	}
+
+	s.warmMu.Lock()
+	defer s.warmMu.Unlock()
+
+	ttl := resolveWarmTTL(cfg)
+	now := s.now()
+	warm := filterWarmAllocations(s.store.List(), pool.Name, backendName)
+	if len(warm) == 0 {
+		return model.AllocationStatus{}, false
+	}
+
+	sortWarmByExpiration(warm)
+	for _, candidate := range warm {
+		if isWarmExpired(candidate, now, ttl) {
+			s.recycleWarmAllocation(ctx, pool, candidate, "warm allocation expired")
+			continue
+		}
+		return candidate, true
+	}
+
+	return model.AllocationStatus{}, false
+}
+
+func (s *Service) recycleWarmAllocation(ctx context.Context, pool model.PoolConfig, status model.AllocationStatus, reason string) {
+	updated, ok := s.store.MarkState(status.ID, model.StateFailed, s.now(), reason)
+	if !ok {
+		return
+	}
+	s.release(ctx, pool, status.SelectedBackend, updated)
+}
+
+func (s *Service) reconcileWarmForPool(pool model.PoolConfig, statuses []model.AllocationStatus, now time.Time) {
+	for backendName, cfg := range pool.Backends {
+		if !isWarmProvisionableBackend(backendName) {
+			continue
+		}
+		s.reconcileWarmForBackend(pool, backendName, cfg, statuses, now)
+	}
+}
+
+func (s *Service) reconcileWarmForBackend(pool model.PoolConfig, backendName model.BackendName, cfg model.BackendConfig, statuses []model.AllocationStatus, now time.Time) {
+	warmMin, warmMax := normalizeWarmBounds(cfg)
+	ttl := resolveWarmTTL(cfg)
+
+	warm := filterWarmAllocations(statuses, pool.Name, backendName)
+
+	if !cfg.Enabled || !cfg.Healthy || cfg.MaxRunners <= 0 {
+		for _, warmStatus := range warm {
+			s.recycleWarmAllocation(context.Background(), pool, warmStatus, "warm backend disabled or unhealthy")
+		}
+		return
+	}
+
+	if warmMax <= 0 {
+		for _, warmStatus := range warm {
+			s.recycleWarmAllocation(context.Background(), pool, warmStatus, "warm disabled")
+		}
+		return
+	}
+
+	sortWarmByExpiration(warm)
+	for _, status := range warm {
+		if isWarmExpired(status, now, ttl) {
+			s.recycleWarmAllocation(context.Background(), pool, status, "warm allocation expired")
+		}
+	}
+
+	warm = filterFreshWarm(s.store.List(), pool.Name, backendName, now, ttl)
+	if len(warm) > warmMax {
+		excess := len(warm) - warmMax
+		for _, status := range warm[len(warm)-excess:] {
+			s.recycleWarmAllocation(context.Background(), pool, status, "warm pool at max capacity")
+		}
+		warm = warm[:warmMax]
+	}
+
+	target := normalizeWarmTarget(warmMin, warmMax, cfg.MaxRunners)
+	for len(warm) < target {
+		if err := s.createWarmAllocation(pool, backendName, now); err != nil {
+			return
+		}
+		warm = append(warm, model.AllocationStatus{})
+	}
+}
+
+func (s *Service) createWarmAllocation(pool model.PoolConfig, backendName model.BackendName, now time.Time) error {
+	cfg, ok := pool.Backends[backendName]
+	if !ok {
+		return fmt.Errorf("backend %q is not configured for pool %q", backendName, pool.Name)
+	}
+	if err := s.validateWarmBackend(pool, backendName); err != nil {
+		return err
+	}
+
+	ttl := resolveWarmTTL(cfg)
+	request := model.AllocationRequest{
+		Pool:    pool.Name,
+		Backend: &backendName,
+	}
+	if cfg.MaxJobDuration > 0 {
+		request.JobTimeout = cfg.MaxJobDuration
+	} else {
+		request.JobTimeout = s.cfg.Broker.DefaultJobTimeout
+	}
+
+	selection, err := s.reserveForBackend(pool, backendName)
+	if err != nil {
+		return err
+	}
+	if selection != backendName {
+		return fmt.Errorf("expected warm reservation for %s, got %s", backendName, selection)
+	}
+
+	allocation := model.AllocationStatus{
+		ID:              newID(),
+		Pool:            pool.Name,
+		SelectedBackend: backendName,
+		CorrelationID:   "",
+		Metadata:        map[string]string{backend.MetadataLaunchModeKey: launchModeWarm},
+		Tenant:          "",
+		PriorityClass:   "",
+		ExpiresAt:       now.Add(ttl),
+		State:           model.StateReserved,
+	}
+
+	backendImpl, ok := s.registry.Get(backendName)
+	if !ok {
+		s.release(context.Background(), pool, backendName, allocation)
+		return fmt.Errorf("backend implementation missing: %s", backendName)
+	}
+
+	provisioned, err := backendImpl.Provision(context.Background(), request, allocation)
+	if err != nil {
+		s.release(context.Background(), pool, backendName, allocation)
+		return err
+	}
+
+	allocation.RunnerLabel = provisioned.RunnerLabel
+	allocation.State = model.StateWarm
+	allocation.Metadata = withLaunchModeMetadata(
+		backend.WithCapabilitiesMetadata(cfg, provisioned.Metadata),
+		launchModeWarm,
+	)
+	allocation.ExpiresAt = now.Add(ttl)
+	s.store.Save(allocation)
+	return nil
+}
+
+func (s *Service) reserveForBackend(pool model.PoolConfig, backendName model.BackendName) (model.BackendName, error) {
+	request := model.AllocationRequest{
+		Pool:    pool.Name,
+		Backend: &backendName,
+	}
+	return s.reserve(pool, request)
+}
+
+func (s *Service) validateWarmBackend(pool model.PoolConfig, backendName model.BackendName) error {
+	cfg, ok := pool.Backends[backendName]
+	if !ok {
+		return fmt.Errorf("backend %q is not configured for pool %q", backendName, pool.Name)
+	}
+	if !cfg.Enabled {
+		return fmt.Errorf("backend %q is not enabled", backendName)
+	}
+	if !cfg.Healthy {
+		return fmt.Errorf("backend %q is unhealthy", backendName)
+	}
+	if !isWarmProvisionableBackend(backendName) {
+		return fmt.Errorf("backend %q does not support warm provisioning", backendName)
+	}
+	return nil
+}
+
+func resolveWarmTTL(cfg model.BackendConfig) time.Duration {
+	if cfg.WarmTTL > 0 {
+		return cfg.WarmTTL
+	}
+	return defaultWarmTTL
+}
+
+func normalizeWarmBounds(cfg model.BackendConfig) (int, int) {
+	min := cfg.WarmMin
+	max := cfg.WarmMax
+	if min < 0 {
+		min = 0
+	}
+	if max < 0 {
+		max = 0
+	}
+	if max < min {
+		max = min
+	}
+	return min, max
+}
+
+func normalizeWarmTarget(min, max, maxRunners int) int {
+	if maxRunners <= 0 {
+		return 0
+	}
+	if max > maxRunners {
+		max = maxRunners
+	}
+	if min < 0 {
+		min = 0
+	}
+	if min > max {
+		min = max
+	}
+	return min
+}
+
+func isWarmExpired(status model.AllocationStatus, now time.Time, ttl time.Duration) bool {
+	if ttl <= 0 {
+		return false
+	}
+	return !status.ExpiresAt.IsZero() && !now.Before(status.ExpiresAt)
+}
+
+func isWarmProvisionableBackend(backendName model.BackendName) bool {
+	switch backendName {
+	case model.BackendARC, model.BackendAzureVM:
+		return false
+	default:
+		return true
+	}
+}
+
+func filterWarmAllocations(statuses []model.AllocationStatus, poolName model.PoolName, backendName model.BackendName) []model.AllocationStatus {
+	result := make([]model.AllocationStatus, 0)
+	for _, status := range statuses {
+		if status.Pool != poolName {
+			continue
+		}
+		if status.SelectedBackend != backendName {
+			continue
+		}
+		if status.State != model.StateWarm {
+			continue
+		}
+		result = append(result, status)
+	}
+	return result
+}
+
+func filterFreshWarm(statuses []model.AllocationStatus, poolName model.PoolName, backendName model.BackendName, now time.Time, ttl time.Duration) []model.AllocationStatus {
+	result := make([]model.AllocationStatus, 0)
+	for _, status := range statuses {
+		if status.Pool != poolName {
+			continue
+		}
+		if status.SelectedBackend != backendName {
+			continue
+		}
+		if status.State != model.StateWarm {
+			continue
+		}
+		if !isWarmExpired(status, now, ttl) {
+			result = append(result, status)
+		}
+	}
+	return result
+}
+
+func sortWarmByExpiration(warm []model.AllocationStatus) {
+	sort.Slice(warm, func(i, j int) bool {
+		if !warm[i].ExpiresAt.Equal(warm[j].ExpiresAt) {
+			return warm[i].ExpiresAt.Before(warm[j].ExpiresAt)
+		}
+		return warm[i].ID < warm[j].ID
+	})
+}
+
+func withLaunchModeMetadata(metadata map[string]string, mode string) map[string]string {
+	if mode == "" {
+		return metadata
+	}
+	cloned := copyStringMap(metadata)
+	cloned[backend.MetadataLaunchModeKey] = mode
+	return cloned
+}
+
+func copyStringMap(source map[string]string) map[string]string {
+	if len(source) == 0 {
+		return map[string]string{}
+	}
+	copied := make(map[string]string, len(source))
+	for key, value := range source {
+		copied[key] = value
+	}
+	return copied
 }
 
 func (s *Service) resolvePool(name model.PoolName) (model.PoolConfig, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -61,6 +61,47 @@ func (b *testCleanupBackend) Cleanup(_ context.Context, _ model.AllocationStatus
 	return errors.New("cleanup failed")
 }
 
+type countingBackend struct {
+	testBackend
+	provisionCount int
+	lastAllocation model.AllocationStatus
+}
+
+func (b *countingBackend) Provision(_ context.Context, _ model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	b.provisionCount++
+	b.lastAllocation = allocation
+	return backend.ProvisionedRunner{
+		RunnerLabel: backend.DefaultRunnerLabel(b.name, allocation.ID),
+		Metadata: map[string]string{
+			"provisioned_by": string(b.name),
+		},
+	}, nil
+}
+
+func newServiceWithCountingBackend(mutator func(*model.PoolConfig), counting *countingBackend) *Service {
+	cfg := config.Default()
+	for index := range cfg.Pools {
+		if mutator != nil {
+			mutator(&cfg.Pools[index])
+		}
+	}
+
+	return NewService(
+		cfg,
+		backend.NewRegistry(
+			testBackend{name: model.BackendARC},
+			counting,
+			testBackend{name: model.BackendLambda},
+			testBackend{name: model.BackendCloudRun},
+			testBackend{name: model.BackendAzureFunctions},
+			testBackend{name: model.BackendAzureVM},
+			testBackend{name: model.BackendEC2},
+			testBackend{name: model.BackendGCE},
+		),
+		nil,
+	)
+}
+
 func newService() *Service {
 	return newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {
@@ -313,6 +354,162 @@ func TestAllocateUsesLambdaWhenLambdaBackendIsEnabled(t *testing.T) {
 	}
 	if allocation.SelectedBackend != model.BackendLambda {
 		t.Fatalf("expected lambda backend, got %s", allocation.SelectedBackend)
+	}
+}
+
+func TestReconcileWarmPoolsCreatesWarmAllocation(t *testing.T) {
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	service := newServiceWithCountingBackend(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 2
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	}, counting)
+
+	service.ReconcileWarmPools()
+
+	statuses := service.store.List()
+	if len(statuses) != 1 {
+		t.Fatalf("expected one warm allocation, got %d", len(statuses))
+	}
+	warm := statuses[0]
+	if warm.State != model.StateWarm {
+		t.Fatalf("expected warm state, got %s", warm.State)
+	}
+	if got := warm.Metadata[backend.MetadataLaunchModeKey]; got != launchModeWarm {
+		t.Fatalf("expected launch mode %q, got %q", launchModeWarm, got)
+	}
+	if counting.provisionCount != 1 {
+		t.Fatalf("expected one warm provisioning call, got %d", counting.provisionCount)
+	}
+}
+
+func TestAllocatePrefersWarmAllocationOverColdLaunch(t *testing.T) {
+	now := time.Unix(1000, 0)
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	service := newServiceWithCountingBackend(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 2
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	}, counting)
+	service.now = func() time.Time { return now }
+
+	service.ReconcileWarmPools()
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("allocation failed: %v", err)
+	}
+	if allocation.Metadata[backend.MetadataLaunchModeKey] != launchModeWarm {
+		t.Fatalf("expected warm launch mode, got %q", allocation.Metadata[backend.MetadataLaunchModeKey])
+	}
+
+	secondAllocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("follow-up allocation failed: %v", err)
+	}
+	if secondAllocation.Metadata[backend.MetadataLaunchModeKey] != launchModeCold {
+		t.Fatalf("expected fallback cold launch mode, got %q", secondAllocation.Metadata[backend.MetadataLaunchModeKey])
+	}
+	if counting.provisionCount != 2 {
+		t.Fatalf("expected one warm then one cold provision call, got %d", counting.provisionCount)
+	}
+
+	var warmCount int
+	for _, status := range service.store.List() {
+		if status.State == model.StateWarm {
+			warmCount++
+		}
+	}
+	if warmCount != 0 {
+		t.Fatalf("expected warm allocation to be consumed, got %d", warmCount)
+	}
+
+	if _, ok := service.Get(secondAllocation.ID); !ok {
+		t.Fatal("expected second allocation to be stored")
+	}
+}
+
+func TestReconcileWarmPoolsRecyclesExpiredWarmAllocation(t *testing.T) {
+	now := time.Unix(1000, 0)
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	service := newServiceWithCountingBackend(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 1
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		codebuildCfg.WarmTTL = time.Minute
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	}, counting)
+	service.now = func() time.Time { return now }
+
+	service.ReconcileWarmPools()
+	if counting.provisionCount != 1 {
+		t.Fatalf("expected one warm provisioning call, got %d", counting.provisionCount)
+	}
+
+	now = now.Add(2 * time.Minute)
+	service.ReconcileWarmPools()
+
+	warmCount := 0
+	for _, status := range service.store.List() {
+		if status.State == model.StateWarm {
+			warmCount++
+		}
+	}
+	if warmCount != 1 {
+		t.Fatalf("expected one active warm allocation after recycle/recreate, got %d", warmCount)
+	}
+	if counting.provisionCount != 2 {
+		t.Fatalf("expected expired warm to be recreated, provision call count=%d", counting.provisionCount)
+	}
+	failedCount := 0
+	for _, status := range service.store.List() {
+		if status.State == model.StateFailed {
+			failedCount++
+		}
+	}
+	if failedCount == 0 {
+		t.Fatalf("expected at least one failed allocation from recycled warm allocation")
+	}
+	if _, ok := service.Get(service.store.List()[0].ID); !ok {
+		t.Fatal("expected active warm allocation to be stored")
 	}
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -10,6 +10,7 @@ import (
 )
 
 const MetadataCapabilitiesKey = "capabilities"
+const MetadataLaunchModeKey = "launch_mode"
 
 type ProvisionedRunner struct {
 	RunnerLabel string

--- a/internal/backend/externaldispatch/backend.go
+++ b/internal/backend/externaldispatch/backend.go
@@ -42,6 +42,7 @@ type dispatchRequest struct {
 	RunnerName        string         `json:"runner_name"`
 	RunnerLabels      []string       `json:"runner_labels"`
 	RequestedLabels   []string       `json:"requested_labels,omitempty"`
+	LaunchMode        string         `json:"launch_mode,omitempty"`
 	JobTimeout        string         `json:"job_timeout"`
 	JobTimeoutSeconds int64          `json:"job_timeout_seconds"`
 	GitHub            dispatchGitHub `json:"github"`
@@ -129,6 +130,7 @@ func (b *Backend) Provision(ctx context.Context, request model.AllocationRequest
 		RunnerName:        runnerLabel,
 		RunnerLabels:      combineLabels(pool.Labels, allocation.RequestedLabels, runnerLabel),
 		RequestedLabels:   append([]string(nil), allocation.RequestedLabels...),
+		LaunchMode:        strings.TrimSpace(allocation.Metadata[backend.MetadataLaunchModeKey]),
 		JobTimeout:        request.JobTimeout.String(),
 		JobTimeoutSeconds: int64(request.JobTimeout / time.Second),
 		GitHub: dispatchGitHub{

--- a/internal/backend/externaldispatch/backend_test.go
+++ b/internal/backend/externaldispatch/backend_test.go
@@ -71,6 +71,9 @@ func TestProvisionDispatchesRunnerLaunch(t *testing.T) {
 		if !contains(payload.RunnerLabels, "uecb-lite") {
 			t.Fatalf("expected pool label to be forwarded, got %v", payload.RunnerLabels)
 		}
+		if payload.LaunchMode != "cold" {
+			t.Fatalf("expected launch mode cold, got %q", payload.LaunchMode)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"execution_id":"run-123","details_url":"https://example.invalid/run-123","metadata":{"provider":"cloud-run"}}`))
@@ -92,6 +95,7 @@ func TestProvisionDispatchesRunnerLaunch(t *testing.T) {
 	}, model.AllocationStatus{
 		ID:              "abc123",
 		Pool:            model.PoolLite,
+		Metadata:        map[string]string{"launch_mode": "cold"},
 		RequestedLabels: []string{"custom-label"},
 	})
 	if err != nil {
@@ -106,6 +110,38 @@ func TestProvisionDispatchesRunnerLaunch(t *testing.T) {
 	}
 	if provisioned.Metadata["execution_id"] != "run-123" {
 		t.Fatalf("expected execution_id metadata, got %+v", provisioned.Metadata)
+	}
+}
+
+func TestProvisionPassesLaunchModeFromAllocationMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload dispatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.LaunchMode != "warm" {
+			t.Fatalf("expected launch_mode warm, got %q", payload.LaunchMode)
+		}
+	}))
+	defer server.Close()
+
+	cfg := newRepoScopedConfig()
+	dispatchBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyDispatchURL: server.URL,
+		},
+	})
+
+	_, err := dispatchBackend.Provision(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	}, model.AllocationStatus{
+		ID:       "abc123",
+		Pool:     model.PoolLite,
+		Metadata: map[string]string{"launch_mode": "warm"},
+	})
+	if err != nil {
+		t.Fatalf("provision failed: %v", err)
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -34,6 +34,7 @@ type AllocationState string
 const (
 	StateReserved    AllocationState = "reserved"
 	StateReady       AllocationState = "ready"
+	StateWarm        AllocationState = "warm"
 	StateCanceled    AllocationState = "canceled"
 	StateExpired     AllocationState = "expired"
 	StateFailed      AllocationState = "failed"
@@ -85,6 +86,9 @@ type BackendConfig struct {
 	Enabled        bool          `yaml:"enabled" json:"enabled"`
 	Healthy        bool          `yaml:"healthy" json:"healthy"`
 	MaxRunners     int           `yaml:"maxRunners" json:"maxRunners"`
+	WarmMin        int           `yaml:"warmMin" json:"warmMin"`
+	WarmMax        int           `yaml:"warmMax" json:"warmMax"`
+	WarmTTL        time.Duration `yaml:"warmTTL,omitempty" json:"warmTTL,omitempty"`
 	Weight         int           `yaml:"weight,omitempty" json:"weight,omitempty"`
 	MaxJobDuration time.Duration `yaml:"maxJobDuration,omitempty" json:"maxJobDuration,omitempty"`
 	Capabilities   []string      `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`

--- a/observability/grafana-dashboard.json
+++ b/observability/grafana-dashboard.json
@@ -47,8 +47,8 @@
       "id": 2,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, pool, backend) (rate(uecb_launch_latency_seconds_bucket[5m])))",
-          "legendFormat": "launch p95 {{pool}}/{{backend}}"
+          "expr": "histogram_quantile(0.95, sum by (le, pool, backend, launch_mode) (rate(uecb_launch_latency_seconds_bucket[5m])))",
+          "legendFormat": "launch p95 {{pool}}/{{backend}} {{launch_mode}}"
         },
         {
           "expr": "histogram_quantile(0.95, sum by (le, pool, backend) (rate(uecb_registration_latency_seconds_bucket[5m])))",


### PR DESCRIPTION
## Summary
- Added warm allocation support in scheduling and allocation lifecycle.
- Added warm allocation background reconciliation and warm-mode metadata/events/metrics labels.
- Updated API and externaldispatch interfaces for launch mode propagation.
- Added docs, helm values, and observability dashboard updates for warm/cold visibility.
- Fixed warm allocation capacity accounting so warm reservation does not inflate scheduler capacity.

Closes #5

## Testing
- go test ./... (pass)
