### PR TITLE
[codex] Add tier-aware backend routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,20 @@ jobs:
           go test ./internal/api ./internal/backend/externaldispatch ./internal/scheduler \
             -run "Test.*Circuit|Test.*Breaker|Test.*Probe|Test.*Timeout|Test.*RateLimit" \
             -count=1
+
+  tier-routing-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Tier routing regression tests
+        run: |
+          go test ./internal/tier/... -count=1
+
+          go test ./internal/api ./internal/config ./internal/runtime \
+            -run "Test.*Tier" \
+            -count=1

--- a/README.md
+++ b/README.md
@@ -255,6 +255,50 @@ pools:
 
 Rollback is just a config change: set `scheduler` back to `round-robin` for the pool and redeploy. Leaving `weight` values in place is safe because the default scheduler ignores them.
 
+## Tier-Aware Routing
+
+Tier-aware routing can keep cloud backends from consuming paid capacity once provider free tiers, budgets, or credits are surpassed or close to exhausted. It is disabled by default and reads cached tier decisions during allocation; Prometheus and provider API calls happen outside the allocation path so runner assignment is not delayed by billing APIs.
+
+```yaml
+broker:
+  tierRouting:
+    enabled: true
+    refreshInterval: 5m
+    staleAfter: 15m
+    failureMode: pass-through-round-robin
+    fallbackBackends:
+      - arc
+    prometheus:
+      url: https://prometheus.example.invalid
+      timeout: 2s
+      secretRef: uecb-prometheus
+    providers:
+      aws-main:
+        provider: aws
+        mode: free-tier
+        secretRef: uecb-aws-billing
+pools:
+  - name: lite
+    backends:
+      codebuild:
+        tierRules:
+          - name: codebuild-free-tier
+            providerRef: aws-main
+            usageQuery: uecb:backend_usage:ratio{backend="codebuild"}
+            burnRateQuery: uecb:backend_usage_burn_rate{backend="codebuild"}
+            softLimitRatio: 0.8
+            hardLimitRatio: 0.95
+            action: observe-only
+```
+
+Supported fallback modes:
+
+- `pass-through-round-robin`: default; unknown or stale tier data does not block builds.
+- `block`: fail allocations when tier data is unknown, stale, or over policy.
+- `fallback-backends`: route to configured fallback backends such as `arc`.
+
+Use `observe-only` first, then move a backend rule to `deprioritize` or `disable` after validating Prometheus queries and provider snapshots. Pinned requests fail clearly when the requested backend is tier-blocked.
+
 ## Runtime Backend Admission
 
 Backends can opt into circuit breaking and cold-launch rate limiting. This is separate from static `enabled` and `healthy`: operator config is still the hard source of truth, while circuit state is learned at runtime per `pool/backend`.

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -56,6 +56,18 @@ config:
       quarantineTTL: 15m
     api:
       oidcAudience: uecb-broker
+    tierRouting:
+      enabled: false
+      refreshInterval: 5m
+      staleAfter: 15m
+      failureMode: pass-through-round-robin
+      fallbackBackends:
+        - arc
+      prometheus:
+        url: ""
+        timeout: 2s
+        secretRef: ""
+      providers: {}
   pools:
     - name: full
       labels:
@@ -136,6 +148,14 @@ config:
           #   permits: 6
           #   interval: 1m
           #   burst: 1
+          # tierRules:
+          #   - name: codebuild-free-tier
+          #     providerRef: aws-main
+          #     usageQuery: uecb:backend_usage:ratio{backend="codebuild"}
+          #     burnRateQuery: uecb:backend_usage_burn_rate{backend="codebuild"}
+          #     softLimitRatio: 0.8
+          #     hardLimitRatio: 0.95
+          #     action: observe-only
           weight: 1
           maxJobDuration: 14m
           capabilities:

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -18,6 +19,7 @@ import (
 	lambdabackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/lambda"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/config"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/runtime"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/tier"
 )
 
 func main() {
@@ -47,6 +49,22 @@ func main() {
 	}
 
 	service := api.NewService(cfg, registry, healthChecker.Check)
+	var tierManager *tier.Manager
+	if cfg.Broker.TierRouting.Enabled {
+		tierManager = tier.NewManager()
+		service.SetTierManager(tierManager)
+		refresher := tier.NewConfigRefresher(cfg, secretReader)
+		if cfg.Broker.TierRouting.RefreshOnStartup {
+			decisions, err := refresher.Refresh(context.Background())
+			if err != nil {
+				log.Printf("initial tier refresh failed: %v", err)
+			}
+			for _, decision := range decisions {
+				tierManager.SetDecision(decision)
+			}
+		}
+		tier.StartRefreshLoop(context.Background(), tierManager, refresher, cfg.Broker.TierRouting.RefreshInterval)
+	}
 	server := api.NewServer(
 		service,
 		[]string{"https://token.actions.githubusercontent.com"},
@@ -77,6 +95,16 @@ func main() {
 			service.ReconcileBackendHealth()
 		}
 	}()
+
+	if tierManager != nil {
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for now := range ticker.C {
+				tierManager.MarkStale(cfg.Broker.TierRouting.StaleAfter, now)
+			}
+		}()
+	}
 
 	addr := os.Getenv("UECB_HTTP_ADDR")
 	if addr == "" {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,20 @@ Circuit state is in-memory and scoped to a single `pool/backend` within one brok
 
 The background backend-health loop probes open circuits and closes them after the configured recovery threshold. Backends without a probe implementation recover through the same success path once the circuit admits a half-open request.
 
+## Tier-Aware Routing
+
+Tier-aware routing is evaluated after static eligibility, capability filtering, timeout filtering, and runtime backend admission, but before scheduler reservation. It uses the same reduced-pool pattern as capability filtering: blocked backends are removed from the pool snapshot passed to the scheduler, and the configured scheduler remains responsible for final selection.
+
+The allocation path only reads cached tier decisions. Prometheus queries and provider budget, free-tier, or credit calls are refreshed out of band and stored in memory per broker process. This keeps allocation latency independent from billing API latency and avoids making `/healthz` depend on cloud billing availability.
+
+Tier states are normalized to `healthy`, `approaching`, `exceeded`, and `unknown`. Rule actions are `observe-only`, `deprioritize`, and `disable`. `observe-only` never changes routing. `disable` removes an approaching or exceeded backend from scheduler eligibility. Unknown or stale data follows `broker.tierRouting.failureMode`:
+
+- `pass-through-round-robin`: default; ignore tier data and preserve build throughput.
+- `block`: fail allocations when tier data is missing, stale, or over policy.
+- `fallback-backends`: route through explicit fallback backends, usually `arc` or another self-hosted label.
+
+Pinned backend requests are not silently rerouted when tier policy blocks the pinned backend. The broker returns a deterministic tier-policy error instead.
+
 ## Capability Filtering
 
 Capability-aware routing is evaluated before scheduler selection.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -35,8 +35,12 @@ Core metrics:
 - `uecb_backend_circuit_transitions_total{pool,backend,from,to,reason}`: circuit open/close transitions.
 - `uecb_backend_admission_rejections_total{pool,backend,reason}`: pre-scheduler backend admission rejections.
 - `uecb_backend_probe_results_total{pool,backend,result}`: background recovery probe results.
+- `uecb_tier_state{pool,backend,state,stale}`: cached tier-routing decision state.
+- `uecb_tier_fallback_total{pool,mode,reason}`: fallback mode activations caused by tier routing.
+- `uecb_tier_blocked_allocations_total{pool,backend,reason}`: allocation attempts blocked by tier routing.
 
 Runtime admission metrics change only when a backend has opted into circuit breaking or rate limiting.
+Tier-routing metrics appear when cached decisions are present or tier policies affect allocation.
 
 ## Artifacts
 
@@ -50,6 +54,8 @@ High allocation latency usually means the broker can accept requests but a backe
 High allocation failure rate means requests are being rejected or backend provisioning is failing. Check broker logs by `correlation_id`, then inspect the selected backend controller logs for the same ID.
 
 Open backend circuits mean the broker is intentionally draining a backend after repeated timeout, wait, throttling, transport, or server-error signals. Check `uecb_backend_circuit_transitions_total` for the trip reason and `uecb_backend_probe_results_total` for recovery progress.
+
+Tier fallback activity means all eligible cloud backends were unavailable under the current tier policy or tier data was stale/unknown. Check `uecb_tier_state` first, then validate the Prometheus recording rules and provider budget/free-tier/credit API responses that feed the cache.
 
 Saturated capacity means the scheduler has few or no healthy slots available for a pool/backend. Check `maxRunners`, runner cleanup, and whether completed jobs are leaving allocations in `ready` or `reserved`.
 

--- a/internal/api/observability.go
+++ b/internal/api/observability.go
@@ -31,6 +31,9 @@ type Observer interface {
 	ObserveBackendCircuitTransition(model.PoolName, model.BackendName, string, string, string)
 	ObserveBackendAdmissionRejected(model.PoolName, model.BackendName, string)
 	ObserveBackendProbe(model.PoolName, model.BackendName, string)
+	ObserveTierState([]tierDecisionSnapshot)
+	ObserveTierFallback(model.PoolName, string, string)
+	ObserveTierBlocked(model.PoolName, model.BackendName, string)
 }
 
 type noopObserver struct{}
@@ -48,6 +51,9 @@ func (noopObserver) ObserveBackendCircuitTransition(model.PoolName, model.Backen
 }
 func (noopObserver) ObserveBackendAdmissionRejected(model.PoolName, model.BackendName, string) {}
 func (noopObserver) ObserveBackendProbe(model.PoolName, model.BackendName, string)             {}
+func (noopObserver) ObserveTierState([]tierDecisionSnapshot)                                   {}
+func (noopObserver) ObserveTierFallback(model.PoolName, string, string)                        {}
+func (noopObserver) ObserveTierBlocked(model.PoolName, model.BackendName, string)              {}
 
 type PrometheusObserver struct {
 	allocationLatency   *prometheus.HistogramVec
@@ -60,6 +66,9 @@ type PrometheusObserver struct {
 	circuitTransitions  *prometheus.CounterVec
 	admissionRejections *prometheus.CounterVec
 	probeResults        *prometheus.CounterVec
+	tierState           *prometheus.GaugeVec
+	tierFallbacks       *prometheus.CounterVec
+	tierBlocked         *prometheus.CounterVec
 }
 
 func NewPrometheusObserver(registerer prometheus.Registerer) *PrometheusObserver {
@@ -111,6 +120,18 @@ func NewPrometheusObserver(registerer prometheus.Registerer) *PrometheusObserver
 			Name: "uecb_backend_probe_results_total",
 			Help: "Background backend recovery probe results.",
 		}, []string{"pool", "backend", "result"}),
+		tierState: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "uecb_tier_state",
+			Help: "Cached tier routing state. A value of 1 marks the active state for a pool/backend.",
+		}, []string{"pool", "backend", "state", "stale"}),
+		tierFallbacks: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "uecb_tier_fallback_total",
+			Help: "Tier routing fallback decisions by pool, mode, and reason.",
+		}, []string{"pool", "mode", "reason"}),
+		tierBlocked: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "uecb_tier_blocked_allocations_total",
+			Help: "Allocation attempts blocked by tier routing.",
+		}, []string{"pool", "backend", "reason"}),
 	}
 }
 
@@ -129,6 +150,9 @@ func (o *PrometheusObserver) Register(registerer prometheus.Registerer) error {
 		o.circuitTransitions,
 		o.admissionRejections,
 		o.probeResults,
+		o.tierState,
+		o.tierFallbacks,
+		o.tierBlocked,
 	} {
 		if err := registerer.Register(collector); err != nil {
 			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
@@ -137,6 +161,38 @@ func (o *PrometheusObserver) Register(registerer prometheus.Registerer) error {
 		}
 	}
 	return nil
+}
+
+type tierDecisionSnapshot struct {
+	Pool    model.PoolName
+	Backend model.BackendName
+	State   string
+	Stale   bool
+}
+
+func (o *PrometheusObserver) ObserveTierState(snapshots []tierDecisionSnapshot) {
+	o.tierState.Reset()
+	for _, snapshot := range snapshots {
+		stale := "false"
+		if snapshot.Stale {
+			stale = "true"
+		}
+		for _, state := range []string{"healthy", "approaching", "exceeded", "unknown"} {
+			value := 0.0
+			if snapshot.State == state {
+				value = 1
+			}
+			o.tierState.WithLabelValues(string(snapshot.Pool), string(snapshot.Backend), state, stale).Set(value)
+		}
+	}
+}
+
+func (o *PrometheusObserver) ObserveTierFallback(pool model.PoolName, mode, reason string) {
+	o.tierFallbacks.WithLabelValues(string(pool), mode, reason).Inc()
+}
+
+func (o *PrometheusObserver) ObserveTierBlocked(pool model.PoolName, backend model.BackendName, reason string) {
+	o.tierBlocked.WithLabelValues(string(pool), string(backend), reason).Inc()
 }
 
 func (o *PrometheusObserver) ObserveBackendCircuitState(snapshots []backendCircuitSnapshot) {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/scheduler"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/store"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/tier"
 )
 
 var ErrUnknownPool = errors.New("pool is not configured")
@@ -23,6 +24,7 @@ var ErrNoMatchingBackendCapabilities = errors.New("no backend matches the reques
 var ErrAllocationNotFound = errors.New("allocation not found")
 var ErrAllocationAlreadyCompleted = errors.New("allocation already in terminal state")
 var ErrInvalidCompletionState = errors.New("invalid completion state")
+var ErrBackendTierBlocked = errors.New("backend tier policy blocked allocation")
 
 const (
 	defaultWarmTTL = 15 * time.Minute
@@ -38,6 +40,7 @@ type Service struct {
 	store     *store.Memory
 	observer  Observer
 	admission *backendAdmission
+	tierMgr   *tier.Manager
 	warmMu    sync.Mutex
 	initErr   error
 	health    func(context.Context) error
@@ -57,10 +60,15 @@ func NewService(cfg model.BrokerConfig, registry *backend.Registry, health func(
 		store:     store.NewMemory(),
 		observer:  noopObserver{},
 		admission: newBackendAdmission(),
+		tierMgr:   tier.NewManager(),
 		initErr:   validateSchedulers(cfg.Pools, schedulerRegistry),
 		health:    health,
 		now:       time.Now,
 	}
+}
+
+func (s *Service) SetTierManager(manager *tier.Manager) {
+	s.tierMgr = manager
 }
 
 func (s *Service) SetObserver(observer Observer) {
@@ -114,6 +122,10 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		}
 	}
 	pool, err = s.filterBackendsByAdmission(pool, request)
+	if err != nil {
+		return model.AllocationStatus{}, err
+	}
+	pool, err = s.filterBackendsByTierState(pool, request)
 	if err != nil {
 		return model.AllocationStatus{}, err
 	}
@@ -418,6 +430,7 @@ func (s *Service) observeState() {
 	s.observer.ObserveActiveAllocations(statuses)
 	s.observer.ObserveCapacity(s.cfg, statuses)
 	s.observeCircuitState()
+	s.observeTierState()
 }
 
 func (s *Service) observeCircuitState() {
@@ -425,6 +438,23 @@ func (s *Service) observeCircuitState() {
 		return
 	}
 	s.observer.ObserveBackendCircuitState(s.admission.stateSnapshot(s.cfg))
+}
+
+func (s *Service) observeTierState() {
+	if s.tierMgr == nil {
+		return
+	}
+	decisions := s.tierMgr.Snapshot()
+	snapshots := make([]tierDecisionSnapshot, 0, len(decisions))
+	for _, decision := range decisions {
+		snapshots = append(snapshots, tierDecisionSnapshot{
+			Pool:    decision.Pool,
+			Backend: decision.Backend,
+			State:   decision.State,
+			Stale:   decision.Stale,
+		})
+	}
+	s.observer.ObserveTierState(snapshots)
 }
 
 func (s *Service) consumeWarmAllocation(ctx context.Context, pool model.PoolConfig, backendName model.BackendName, request model.AllocationStatus) (model.AllocationStatus, bool) {
@@ -491,6 +521,12 @@ func (s *Service) reconcileWarmForBackend(pool model.PoolConfig, backendName mod
 		}
 		return
 	}
+	if s.backendTierBlockedForWarm(pool.Name, backendName) {
+		for _, warmStatus := range warm {
+			s.recycleWarmAllocation(context.Background(), pool, warmStatus, "warm backend blocked by tier policy")
+		}
+		return
+	}
 
 	sortWarmByExpiration(warm)
 	for _, status := range warm {
@@ -530,6 +566,9 @@ func (s *Service) createWarmAllocation(pool model.PoolConfig, backendName model.
 		if !decision.Allowed {
 			return fmt.Errorf("warm backend %q is not admissible: %s", backendName, decision.Reason)
 		}
+	}
+	if s.backendTierBlockedForWarm(pool.Name, backendName) {
+		return fmt.Errorf("warm backend %q is blocked by tier policy", backendName)
 	}
 
 	ttl := resolveWarmTTL(cfg)
@@ -620,6 +659,206 @@ func (s *Service) filterBackendsByAdmission(pool model.PoolConfig, request model
 		}
 	}
 	return filtered, nil
+}
+
+func (s *Service) filterBackendsByTierState(pool model.PoolConfig, request model.AllocationRequest) (model.PoolConfig, error) {
+	if !s.cfg.Broker.TierRouting.Enabled || s.tierMgr == nil {
+		return pool, nil
+	}
+	eligible, deprioritized, blocked := s.tierEligibleBackends(pool)
+	if request.Backend != nil {
+		if _, ok := pool.Backends[*request.Backend]; !ok {
+			return model.PoolConfig{}, scheduler.ErrUnknownBackend
+		}
+		if s.pinnedBackendAllowedByTier(pool.Name, *request.Backend) {
+			return pool, nil
+		}
+		if _, ok := eligible.Backends[*request.Backend]; ok {
+			return eligible, nil
+		}
+		if _, ok := deprioritized.Backends[*request.Backend]; ok {
+			return deprioritized, nil
+		}
+		decision := blocked[*request.Backend]
+		s.observer.ObserveTierBlocked(pool.Name, *request.Backend, tierBlockReason(decision))
+		return model.PoolConfig{}, fmt.Errorf("pinned backend %q is blocked by tier policy: %w", *request.Backend, ErrBackendTierBlocked)
+	}
+	if len(eligible.Backends) > 0 {
+		return eligible, nil
+	}
+	if len(deprioritized.Backends) > 0 {
+		s.observer.ObserveTierFallback(pool.Name, "deprioritize", "approaching")
+		return deprioritized, nil
+	}
+	if len(blocked) == 0 {
+		return pool, nil
+	}
+
+	mode := normalizeTierFailureMode(s.cfg.Broker.TierRouting.FailureMode)
+	switch mode {
+	case tier.FailureModeBlock:
+		s.observer.ObserveTierFallback(pool.Name, mode, "all-backends-blocked")
+		return model.PoolConfig{}, fmt.Errorf("%w for pool %q", ErrBackendTierBlocked, pool.Name)
+	case tier.FailureModeFallback:
+		fallback := filterTierFallbackBackends(pool, s.cfg.Broker.TierRouting.FallbackBackends)
+		if len(fallback.Backends) > 0 {
+			s.observer.ObserveTierFallback(pool.Name, mode, "fallback-backends")
+			return fallback, nil
+		}
+		s.observer.ObserveTierFallback(pool.Name, mode, "fallback-empty")
+		return model.PoolConfig{}, fmt.Errorf("%w for pool %q: no fallback backends available", ErrBackendTierBlocked, pool.Name)
+	default:
+		s.observer.ObserveTierFallback(pool.Name, tier.FailureModePassThrough, "pass-through")
+		return pool, nil
+	}
+}
+
+func (s *Service) tierEligibleBackends(pool model.PoolConfig) (model.PoolConfig, model.PoolConfig, map[model.BackendName]tier.Decision) {
+	filtered := pool
+	filtered.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+	deprioritized := pool
+	deprioritized.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+	blocked := map[model.BackendName]tier.Decision{}
+	for name, cfg := range pool.Backends {
+		decision, ok := s.tierMgr.Decision(pool.Name, name)
+		if !ok {
+			decision = tier.Decision{
+				Pool:    pool.Name,
+				Backend: name,
+				State:   tier.StateUnknown,
+				Action:  tier.ActionDisable,
+				Reason:  "missing tier data",
+			}
+		}
+		if s.tierDecisionAllowsBackendNormally(decision) {
+			if !s.backendHasFreeSchedulerCapacity(pool, name, cfg) {
+				continue
+			}
+			filtered.Backends[name] = cfg
+			continue
+		}
+		if tierDecisionIsDeprioritized(decision) {
+			if !s.backendHasFreeSchedulerCapacity(pool, name, cfg) {
+				continue
+			}
+			deprioritized.Backends[name] = cfg
+			continue
+		}
+		blocked[name] = decision
+		s.observer.ObserveTierBlocked(pool.Name, name, tierBlockReason(decision))
+	}
+	return filtered, deprioritized, blocked
+}
+
+func (s *Service) pinnedBackendAllowedByTier(pool model.PoolName, backendName model.BackendName) bool {
+	decision, ok := s.tierMgr.Decision(pool, backendName)
+	if !ok {
+		decision = tier.Decision{
+			Pool:    pool,
+			Backend: backendName,
+			State:   tier.StateUnknown,
+			Action:  tier.ActionDisable,
+			Reason:  "missing tier data",
+		}
+	}
+	if decision.Action == tier.ActionObserveOnly {
+		return true
+	}
+	if decision.Stale || decision.State == tier.StateUnknown {
+		return normalizeTierFailureMode(s.cfg.Broker.TierRouting.FailureMode) == tier.FailureModePassThrough
+	}
+	if decision.State == tier.StateHealthy {
+		return true
+	}
+	if decision.State == tier.StateApproaching {
+		return decision.Action != tier.ActionDisable
+	}
+	return false
+}
+
+func (s *Service) tierDecisionAllowsBackendNormally(decision tier.Decision) bool {
+	if decision.Action == tier.ActionObserveOnly {
+		return true
+	}
+	if decision.Stale || decision.State == tier.StateUnknown {
+		return normalizeTierFailureMode(s.cfg.Broker.TierRouting.FailureMode) == tier.FailureModePassThrough
+	}
+	if decision.State == tier.StateHealthy {
+		return true
+	}
+	return false
+}
+
+func tierDecisionIsDeprioritized(decision tier.Decision) bool {
+	return !decision.Stale && decision.State == tier.StateApproaching && decision.Action == tier.ActionDeprioritize
+}
+
+func (s *Service) backendTierBlockedForWarm(pool model.PoolName, backendName model.BackendName) bool {
+	if !s.cfg.Broker.TierRouting.Enabled || s.tierMgr == nil {
+		return false
+	}
+	decision, ok := s.tierMgr.Decision(pool, backendName)
+	if !ok {
+		return normalizeTierFailureMode(s.cfg.Broker.TierRouting.FailureMode) == tier.FailureModeBlock
+	}
+	if decision.Action == tier.ActionObserveOnly {
+		return false
+	}
+	if decision.Stale || decision.State == tier.StateUnknown {
+		return normalizeTierFailureMode(s.cfg.Broker.TierRouting.FailureMode) == tier.FailureModeBlock
+	}
+	return decision.State == tier.StateExceeded || (decision.State == tier.StateApproaching && decision.Action == tier.ActionDisable)
+}
+
+func (s *Service) backendHasFreeSchedulerCapacity(pool model.PoolConfig, backendName model.BackendName, cfg model.BackendConfig) bool {
+	if !cfg.Enabled || !cfg.Healthy || cfg.MaxRunners <= 0 {
+		return false
+	}
+	active := 0
+	if pool.FairShare.Enabled {
+		if s.fairShare != nil {
+			active = s.fairShare.Active(pool.Name, backendName)
+		}
+	} else {
+		active = s.schedulerForPool(pool).Active(pool.Name, backendName)
+	}
+	return active < cfg.MaxRunners
+}
+
+func filterTierFallbackBackends(pool model.PoolConfig, fallbackBackends []model.BackendName) model.PoolConfig {
+	filtered := pool
+	filtered.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+	allowed := map[model.BackendName]struct{}{}
+	for _, backendName := range fallbackBackends {
+		allowed[backendName] = struct{}{}
+	}
+	for name, cfg := range pool.Backends {
+		if _, ok := allowed[name]; ok {
+			filtered.Backends[name] = cfg
+		}
+	}
+	return filtered
+}
+
+func normalizeTierFailureMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case tier.FailureModeBlock:
+		return tier.FailureModeBlock
+	case tier.FailureModeFallback:
+		return tier.FailureModeFallback
+	default:
+		return tier.FailureModePassThrough
+	}
+}
+
+func tierBlockReason(decision tier.Decision) string {
+	if decision.State == "" {
+		return "unknown"
+	}
+	if decision.Stale {
+		return "stale-" + decision.State
+	}
+	return decision.State
 }
 
 func (s *Service) recordBackendFailure(pool model.PoolConfig, backendName model.BackendName, err error, now time.Time) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/config"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/scheduler"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/tier"
 )
 
 type testBackend struct {
@@ -160,6 +161,27 @@ func newServiceWithConfig(mutator func(*model.PoolConfig)) *Service {
 	)
 }
 
+func newServiceWithBrokerConfig(mutator func(*model.BrokerConfig)) *Service {
+	cfg := config.Default()
+	if mutator != nil {
+		mutator(&cfg)
+	}
+	return NewService(
+		cfg,
+		backend.NewRegistry(
+			testBackend{name: model.BackendARC},
+			testBackend{name: model.BackendCodeBuild},
+			testBackend{name: model.BackendLambda},
+			testBackend{name: model.BackendCloudRun},
+			testBackend{name: model.BackendAzureFunctions},
+			testBackend{name: model.BackendAzureVM},
+			testBackend{name: model.BackendEC2},
+			testBackend{name: model.BackendGCE},
+		),
+		nil,
+	)
+}
+
 func TestAllocateUsesWeightedSchedulerForPool(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {
@@ -197,6 +219,159 @@ func TestAllocateUsesWeightedSchedulerForPool(t *testing.T) {
 		if _, ok := service.Cancel(allocation.ID); !ok {
 			t.Fatalf("cancel #%d failed", index+1)
 		}
+	}
+}
+
+func TestAllocateSkipsTierExceededBackend(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.TierRouting.Enabled = true
+		for index := range cfg.Pools {
+			if cfg.Pools[index].Name != model.PoolLite {
+				continue
+			}
+			codebuildCfg := cfg.Pools[index].Backends[model.BackendCodeBuild]
+			codebuildCfg.Enabled = true
+			codebuildCfg.MaxRunners = 1
+			cfg.Pools[index].Backends[model.BackendCodeBuild] = codebuildCfg
+		}
+	})
+	manager := tier.NewManager()
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendARC, State: tier.StateExceeded, Action: tier.ActionDisable, UpdatedAt: time.Now()})
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendCodeBuild, State: tier.StateHealthy, Action: tier.ActionDisable, UpdatedAt: time.Now()})
+	service.SetTierManager(manager)
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+	if allocation.SelectedBackend != model.BackendCodeBuild {
+		t.Fatalf("expected codebuild after tier filtering, got %s", allocation.SelectedBackend)
+	}
+}
+
+func TestAllocateUsesDeprioritizedBackendOnlyAfterHealthyBackends(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.TierRouting.Enabled = true
+		for index := range cfg.Pools {
+			if cfg.Pools[index].Name != model.PoolLite {
+				continue
+			}
+			codebuildCfg := cfg.Pools[index].Backends[model.BackendCodeBuild]
+			codebuildCfg.Enabled = true
+			codebuildCfg.MaxRunners = 1
+			cfg.Pools[index].Backends[model.BackendCodeBuild] = codebuildCfg
+
+			arcCfg := cfg.Pools[index].Backends[model.BackendARC]
+			arcCfg.MaxRunners = 1
+			cfg.Pools[index].Backends[model.BackendARC] = arcCfg
+		}
+	})
+	manager := tier.NewManager()
+	now := time.Now()
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendARC, State: tier.StateApproaching, Action: tier.ActionDeprioritize, UpdatedAt: now})
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendCodeBuild, State: tier.StateHealthy, Action: tier.ActionDisable, UpdatedAt: now})
+	service.SetTierManager(manager)
+
+	first, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite})
+	if err != nil {
+		t.Fatalf("first allocate failed: %v", err)
+	}
+	if first.SelectedBackend != model.BackendCodeBuild {
+		t.Fatalf("expected healthy codebuild before deprioritized arc, got %s", first.SelectedBackend)
+	}
+
+	second, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite})
+	if err != nil {
+		t.Fatalf("second allocate failed: %v", err)
+	}
+	if second.SelectedBackend != model.BackendARC {
+		t.Fatalf("expected deprioritized arc after healthy capacity is full, got %s", second.SelectedBackend)
+	}
+}
+
+func TestAllocateRejectsPinnedTierBlockedBackend(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.TierRouting.Enabled = true
+	})
+	manager := tier.NewManager()
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendARC, State: tier.StateExceeded, Action: tier.ActionDisable, UpdatedAt: time.Now()})
+	service.SetTierManager(manager)
+
+	pinned := model.BackendARC
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite, Backend: &pinned})
+	if !errors.Is(err, ErrBackendTierBlocked) {
+		t.Fatalf("expected tier blocked error, got %v", err)
+	}
+}
+
+func TestPinnedHealthyTierBackendStillReturnsCapacityErrorWhenFull(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.TierRouting.Enabled = true
+		for index := range cfg.Pools {
+			if cfg.Pools[index].Name != model.PoolLite {
+				continue
+			}
+			arcCfg := cfg.Pools[index].Backends[model.BackendARC]
+			arcCfg.MaxRunners = 1
+			cfg.Pools[index].Backends[model.BackendARC] = arcCfg
+		}
+	})
+	manager := tier.NewManager()
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendARC, State: tier.StateHealthy, Action: tier.ActionDisable, UpdatedAt: time.Now()})
+	service.SetTierManager(manager)
+
+	pinned := model.BackendARC
+	if _, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite, Backend: &pinned}); err != nil {
+		t.Fatalf("first pinned allocation failed: %v", err)
+	}
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite, Backend: &pinned})
+	if !errors.Is(err, scheduler.ErrNoCapacity) {
+		t.Fatalf("expected capacity error for full pinned backend, got %v", err)
+	}
+}
+
+func TestAllocatePassesThroughUnknownTierStateByDefault(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.TierRouting.Enabled = true
+	})
+	service.SetTierManager(tier.NewManager())
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+	if allocation.SelectedBackend == "" {
+		t.Fatal("expected allocation to pass through unknown tier state")
+	}
+}
+
+func TestAllocateUsesTierFallbackBackends(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.TierRouting.Enabled = true
+		cfg.Broker.TierRouting.FailureMode = tier.FailureModeFallback
+		cfg.Broker.TierRouting.FallbackBackends = []model.BackendName{model.BackendARC}
+		for index := range cfg.Pools {
+			if cfg.Pools[index].Name != model.PoolLite {
+				continue
+			}
+			codebuildCfg := cfg.Pools[index].Backends[model.BackendCodeBuild]
+			codebuildCfg.Enabled = true
+			codebuildCfg.MaxRunners = 1
+			cfg.Pools[index].Backends[model.BackendCodeBuild] = codebuildCfg
+		}
+	})
+	manager := tier.NewManager()
+	for _, backendName := range []model.BackendName{model.BackendARC, model.BackendCodeBuild} {
+		manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: backendName, State: tier.StateExceeded, Action: tier.ActionDisable, UpdatedAt: time.Now()})
+	}
+	service.SetTierManager(manager)
+
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolLite})
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+	if allocation.SelectedBackend != model.BackendARC {
+		t.Fatalf("expected arc fallback, got %s", allocation.SelectedBackend)
 	}
 }
 
@@ -693,6 +868,39 @@ func TestReconcileWarmPoolsCreatesWarmAllocation(t *testing.T) {
 	}
 	if counting.provisionCount != 1 {
 		t.Fatalf("expected one warm provisioning call, got %d", counting.provisionCount)
+	}
+}
+
+func TestReconcileWarmPoolsSkipsTierBlockedBackend(t *testing.T) {
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	service := newServiceWithCountingBackend(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 2
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	}, counting)
+	service.cfg.Broker.TierRouting.Enabled = true
+	manager := tier.NewManager()
+	manager.SetDecision(tier.Decision{Pool: model.PoolLite, Backend: model.BackendCodeBuild, State: tier.StateExceeded, Action: tier.ActionDisable, UpdatedAt: time.Now()})
+	service.SetTierManager(manager)
+
+	service.ReconcileWarmPools()
+
+	if counting.provisionCount != 0 {
+		t.Fatalf("expected tier-blocked backend not to prewarm, got %d provisions", counting.provisionCount)
+	}
+	if statuses := service.store.List(); len(statuses) != 0 {
+		t.Fatalf("expected no warm allocations, got %+v", statuses)
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -34,6 +34,15 @@ func Default() model.BrokerConfig {
 			API: model.BrokerAPIConfig{
 				OIDCAudience: "uecb-broker",
 			},
+			TierRouting: model.TierRoutingConfig{
+				Enabled:         false,
+				RefreshInterval: 5 * time.Minute,
+				StaleAfter:      15 * time.Minute,
+				FailureMode:     "pass-through-round-robin",
+				Prometheus: model.TierPrometheusConfig{
+					Timeout: 2 * time.Second,
+				},
+			},
 		},
 		Pools: []model.PoolConfig{
 			{
@@ -161,6 +170,9 @@ func Load(path string) (model.BrokerConfig, error) {
 
 	cfg := Default()
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return model.BrokerConfig{}, err
+	}
+	if err := Validate(cfg); err != nil {
 		return model.BrokerConfig{}, err
 	}
 	return cfg, nil

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -83,6 +83,116 @@ pools:
 	}
 }
 
+func TestLoadParsesTierRoutingConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broker.yaml")
+	if err := os.WriteFile(path, []byte(`
+broker:
+  tierRouting:
+    enabled: true
+    refreshInterval: 2m
+    staleAfter: 6m
+    failureMode: fallback-backends
+    fallbackBackends:
+      - codebuild
+    prometheus:
+      url: https://prometheus.example.invalid
+      timeout: 3s
+      secretRef: uecb-prometheus
+    providers:
+      aws-main:
+        provider: aws
+        mode: free-tier
+        secretRef: uecb-aws-billing
+pools:
+  - name: lite
+    backends:
+      codebuild:
+        tierRules:
+          - name: codebuild-free-tier
+            providerRef: aws-main
+            usageQuery: uecb:backend_usage:ratio
+            softLimitRatio: 0.75
+            hardLimitRatio: 0.9
+            minRemainingCredit: 2
+            action: disable
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if !cfg.Broker.TierRouting.Enabled {
+		t.Fatal("expected tier routing to be enabled")
+	}
+	if cfg.Broker.TierRouting.RefreshInterval != 2*time.Minute {
+		t.Fatalf("unexpected refresh interval: %s", cfg.Broker.TierRouting.RefreshInterval)
+	}
+	if cfg.Broker.TierRouting.Prometheus.SecretRef != "uecb-prometheus" {
+		t.Fatalf("unexpected prometheus secret ref: %q", cfg.Broker.TierRouting.Prometheus.SecretRef)
+	}
+	provider := cfg.Broker.TierRouting.Providers["aws-main"]
+	if provider.Provider != "aws" || provider.Mode != "free-tier" || provider.SecretRef != "uecb-aws-billing" {
+		t.Fatalf("unexpected provider config: %+v", provider)
+	}
+	rule := cfg.Pools[0].Backends[model.BackendCodeBuild].TierRules[0]
+	if rule.ProviderRef != "aws-main" || rule.Action != "disable" || rule.HardLimitRatio != 0.9 {
+		t.Fatalf("unexpected tier rule: %+v", rule)
+	}
+}
+
+func TestLoadRejectsInvalidTierRoutingConfig(t *testing.T) {
+	cases := map[string]string{
+		"invalid provider ref": `
+broker:
+  tierRouting:
+    enabled: true
+    prometheus:
+      url: https://prometheus.example.invalid
+pools:
+  - name: lite
+    backends:
+      codebuild:
+        tierRules:
+          - providerRef: missing-provider
+`,
+		"invalid threshold order": `
+broker:
+  tierRouting:
+    enabled: true
+    prometheus:
+      url: https://prometheus.example.invalid
+pools:
+  - name: lite
+    backends:
+      codebuild:
+        tierRules:
+          - usageQuery: uecb:usage
+            softLimitRatio: 0.95
+            hardLimitRatio: 0.8
+`,
+		"fallback without backends": `
+broker:
+  tierRouting:
+    enabled: true
+    failureMode: fallback-backends
+`,
+	}
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "broker.yaml")
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if _, err := Load(path); err == nil {
+				t.Fatal("expected invalid tier routing config to fail")
+			}
+		})
+	}
+}
+
 func TestDefaultIncludesDockerAndVMBackends(t *testing.T) {
 	cfg := Default()
 	pool := cfg.Pools[1]

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+const (
+	tierFailureModePassThrough = "pass-through-round-robin"
+	tierFailureModeBlock       = "block"
+	tierFailureModeFallback    = "fallback-backends"
+
+	tierActionObserveOnly  = "observe-only"
+	tierActionDeprioritize = "deprioritize"
+	tierActionDisable      = "disable"
+
+	tierCombineMostRestrictive = "most-restrictive"
+)
+
+func Validate(cfg model.BrokerConfig) error {
+	if err := validateTierRouting(cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTierRouting(cfg model.BrokerConfig) error {
+	tierCfg := cfg.Broker.TierRouting
+	if !tierCfg.Enabled && !hasTierRules(cfg) {
+		return nil
+	}
+
+	failureMode := normalizeStringDefault(tierCfg.FailureMode, tierFailureModePassThrough)
+	switch failureMode {
+	case tierFailureModePassThrough, tierFailureModeBlock, tierFailureModeFallback:
+	default:
+		return fmt.Errorf("broker.tierRouting.failureMode %q is not supported", tierCfg.FailureMode)
+	}
+
+	if tierCfg.RefreshInterval < 0 {
+		return fmt.Errorf("broker.tierRouting.refreshInterval must not be negative")
+	}
+	if tierCfg.StaleAfter < 0 {
+		return fmt.Errorf("broker.tierRouting.staleAfter must not be negative")
+	}
+	if tierCfg.Prometheus.Timeout < 0 {
+		return fmt.Errorf("broker.tierRouting.prometheus.timeout must not be negative")
+	}
+
+	if failureMode == tierFailureModeFallback {
+		if len(tierCfg.FallbackBackends) == 0 {
+			return fmt.Errorf("broker.tierRouting.fallbackBackends is required when failureMode is %q", tierFailureModeFallback)
+		}
+		for _, backendName := range tierCfg.FallbackBackends {
+			if !backendNameConfigured(cfg, backendName) {
+				return fmt.Errorf("broker.tierRouting.fallbackBackends includes unknown backend %q", backendName)
+			}
+		}
+	}
+
+	for ref, provider := range tierCfg.Providers {
+		if strings.TrimSpace(ref) == "" {
+			return fmt.Errorf("broker.tierRouting.providers includes an empty provider ref")
+		}
+		switch normalizeString(provider.Provider) {
+		case "aws", "azure", "gcp":
+		default:
+			return fmt.Errorf("broker.tierRouting.providers.%s.provider %q is not supported", ref, provider.Provider)
+		}
+		if strings.TrimSpace(provider.Mode) == "" {
+			return fmt.Errorf("broker.tierRouting.providers.%s.mode is required", ref)
+		}
+	}
+
+	for _, pool := range cfg.Pools {
+		for backendName, backendCfg := range pool.Backends {
+			for index, rule := range backendCfg.TierRules {
+				if err := validateTierRule(tierCfg, pool.Name, backendName, index, rule); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateTierRule(tierCfg model.TierRoutingConfig, pool model.PoolName, backend model.BackendName, index int, rule model.TierRuleConfig) error {
+	prefix := fmt.Sprintf("pools[%s].backends[%s].tierRules[%d]", pool, backend, index)
+	action := normalizeStringDefault(rule.Action, tierActionDisable)
+	switch action {
+	case tierActionObserveOnly, tierActionDeprioritize, tierActionDisable:
+	default:
+		return fmt.Errorf("%s.action %q is not supported", prefix, rule.Action)
+	}
+
+	combine := normalizeStringDefault(rule.Combine, tierCombineMostRestrictive)
+	if combine != tierCombineMostRestrictive {
+		return fmt.Errorf("%s.combine %q is not supported", prefix, rule.Combine)
+	}
+
+	if rule.SoftLimitRatio < 0 || rule.SoftLimitRatio > 1 {
+		return fmt.Errorf("%s.softLimitRatio must be between 0 and 1", prefix)
+	}
+	if rule.HardLimitRatio < 0 || rule.HardLimitRatio > 1 {
+		return fmt.Errorf("%s.hardLimitRatio must be between 0 and 1", prefix)
+	}
+	if rule.SoftLimitRatio > 0 && rule.HardLimitRatio > 0 && rule.SoftLimitRatio > rule.HardLimitRatio {
+		return fmt.Errorf("%s.softLimitRatio must be less than or equal to hardLimitRatio", prefix)
+	}
+	if rule.MinRemainingCredit < 0 {
+		return fmt.Errorf("%s.minRemainingCredit must not be negative", prefix)
+	}
+	if rule.ProjectionWindow < 0 {
+		return fmt.Errorf("%s.projectionWindow must not be negative", prefix)
+	}
+
+	if strings.TrimSpace(rule.ProviderRef) != "" {
+		if _, ok := tierCfg.Providers[rule.ProviderRef]; !ok {
+			return fmt.Errorf("%s.providerRef %q does not match a configured provider", prefix, rule.ProviderRef)
+		}
+	}
+	if strings.TrimSpace(rule.ProviderRef) == "" && strings.TrimSpace(rule.UsageQuery) == "" && strings.TrimSpace(rule.BurnRateQuery) == "" {
+		return fmt.Errorf("%s must define providerRef, usageQuery, or burnRateQuery", prefix)
+	}
+	if (strings.TrimSpace(rule.UsageQuery) != "" || strings.TrimSpace(rule.BurnRateQuery) != "") && strings.TrimSpace(tierCfg.Prometheus.URL) == "" {
+		return fmt.Errorf("%s uses prometheus queries but broker.tierRouting.prometheus.url is empty", prefix)
+	}
+	return nil
+}
+
+func hasTierRules(cfg model.BrokerConfig) bool {
+	for _, pool := range cfg.Pools {
+		for _, backend := range pool.Backends {
+			if len(backend.TierRules) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func backendNameConfigured(cfg model.BrokerConfig, name model.BackendName) bool {
+	for _, pool := range cfg.Pools {
+		if _, ok := pool.Backends[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeString(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeStringDefault(value, fallback string) string {
+	normalized := normalizeString(value)
+	if normalized == "" {
+		return fallback
+	}
+	return normalized
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -79,7 +79,38 @@ type BrokerRuntimeConfig struct {
 		Enabled       bool          `yaml:"enabled" json:"enabled"`
 		QuarantineTTL time.Duration `yaml:"quarantineTTL" json:"quarantineTTL"`
 	} `yaml:"orphanCleanup" json:"orphanCleanup"`
-	API BrokerAPIConfig `yaml:"api" json:"api"`
+	API         BrokerAPIConfig   `yaml:"api" json:"api"`
+	TierRouting TierRoutingConfig `yaml:"tierRouting,omitempty" json:"tierRouting,omitempty"`
+}
+
+type TierRoutingConfig struct {
+	Enabled          bool                          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	RefreshInterval  time.Duration                 `yaml:"refreshInterval,omitempty" json:"refreshInterval,omitempty"`
+	StaleAfter       time.Duration                 `yaml:"staleAfter,omitempty" json:"staleAfter,omitempty"`
+	FailureMode      string                        `yaml:"failureMode,omitempty" json:"failureMode,omitempty"`
+	FallbackBackends []BackendName                 `yaml:"fallbackBackends,omitempty" json:"fallbackBackends,omitempty"`
+	Prometheus       TierPrometheusConfig          `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
+	Providers        map[string]TierProviderConfig `yaml:"providers,omitempty" json:"providers,omitempty"`
+	RefreshOnStartup bool                          `yaml:"refreshOnStartup,omitempty" json:"refreshOnStartup,omitempty"`
+}
+
+type TierPrometheusConfig struct {
+	URL       string        `yaml:"url,omitempty" json:"url,omitempty"`
+	Timeout   time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	SecretRef string        `yaml:"secretRef,omitempty" json:"secretRef,omitempty"`
+}
+
+type TierProviderConfig struct {
+	Provider         string            `yaml:"provider,omitempty" json:"provider,omitempty"`
+	Mode             string            `yaml:"mode,omitempty" json:"mode,omitempty"`
+	SecretRef        string            `yaml:"secretRef,omitempty" json:"secretRef,omitempty"`
+	AccountID        string            `yaml:"accountId,omitempty" json:"accountId,omitempty"`
+	SubscriptionID   string            `yaml:"subscriptionId,omitempty" json:"subscriptionId,omitempty"`
+	ProjectID        string            `yaml:"projectId,omitempty" json:"projectId,omitempty"`
+	BillingAccountID string            `yaml:"billingAccountId,omitempty" json:"billingAccountId,omitempty"`
+	BudgetName       string            `yaml:"budgetName,omitempty" json:"budgetName,omitempty"`
+	Region           string            `yaml:"region,omitempty" json:"region,omitempty"`
+	Labels           map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 }
 
 type CircuitBreakerConfig struct {
@@ -116,6 +147,22 @@ type BackendConfig struct {
 	SecretRef      string               `yaml:"secretRef,omitempty" json:"secretRef,omitempty"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuitBreaker,omitempty" json:"circuitBreaker,omitempty"`
 	RateLimit      RateLimitConfig      `yaml:"rateLimit,omitempty" json:"rateLimit,omitempty"`
+	TierRules      []TierRuleConfig     `yaml:"tierRules,omitempty" json:"tierRules,omitempty"`
+}
+
+type TierRuleConfig struct {
+	Name               string        `yaml:"name,omitempty" json:"name,omitempty"`
+	ProviderRef        string        `yaml:"providerRef,omitempty" json:"providerRef,omitempty"`
+	Dimension          string        `yaml:"dimension,omitempty" json:"dimension,omitempty"`
+	UsageQuery         string        `yaml:"usageQuery,omitempty" json:"usageQuery,omitempty"`
+	BurnRateQuery      string        `yaml:"burnRateQuery,omitempty" json:"burnRateQuery,omitempty"`
+	LimitSources       []string      `yaml:"limitSources,omitempty" json:"limitSources,omitempty"`
+	Combine            string        `yaml:"combine,omitempty" json:"combine,omitempty"`
+	SoftLimitRatio     float64       `yaml:"softLimitRatio,omitempty" json:"softLimitRatio,omitempty"`
+	HardLimitRatio     float64       `yaml:"hardLimitRatio,omitempty" json:"hardLimitRatio,omitempty"`
+	MinRemainingCredit float64       `yaml:"minRemainingCredit,omitempty" json:"minRemainingCredit,omitempty"`
+	ProjectionWindow   time.Duration `yaml:"projectionWindow,omitempty" json:"projectionWindow,omitempty"`
+	Action             string        `yaml:"action,omitempty" json:"action,omitempty"`
 }
 
 type FairShareConfig struct {

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -1,11 +1,11 @@
 package runtime
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -231,6 +231,17 @@ func requiredSecretRefs(cfg model.BrokerConfig) []string {
 				continue
 			}
 			if ref := strings.TrimSpace(backend.SecretRef); ref != "" {
+				refs[ref] = struct{}{}
+			}
+		}
+	}
+
+	if cfg.Broker.TierRouting.Enabled {
+		if ref := strings.TrimSpace(cfg.Broker.TierRouting.Prometheus.SecretRef); ref != "" {
+			refs[ref] = struct{}{}
+		}
+		for _, provider := range cfg.Broker.TierRouting.Providers {
+			if ref := strings.TrimSpace(provider.SecretRef); ref != "" {
 				refs[ref] = struct{}{}
 			}
 		}

--- a/internal/runtime/secrets_test.go
+++ b/internal/runtime/secrets_test.go
@@ -30,6 +30,27 @@ func TestRequiredSecretRefsSkipsDisabledBackends(t *testing.T) {
 	}
 }
 
+func TestRequiredSecretRefsIncludesEnabledTierRoutingSecrets(t *testing.T) {
+	cfg := config.Default()
+	cfg.Broker.TierRouting.Enabled = true
+	cfg.Broker.TierRouting.Prometheus.SecretRef = "uecb-prometheus"
+	cfg.Broker.TierRouting.Providers = map[string]model.TierProviderConfig{
+		"aws-main": {
+			Provider:  "aws",
+			Mode:      "free-tier",
+			SecretRef: "uecb-aws-billing",
+		},
+	}
+
+	refs := requiredSecretRefs(cfg)
+	sort.Strings(refs)
+	got := strings.Join(refs, ",")
+	want := "uecb-aws-billing,uecb-github-app,uecb-prometheus"
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
 func TestSecretRefCheckerReportsMissingSecret(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)

--- a/internal/tier/cache.go
+++ b/internal/tier/cache.go
@@ -1,0 +1,83 @@
+package tier
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+type Manager struct {
+	mu        sync.RWMutex
+	decisions map[key]Decision
+}
+
+type key struct {
+	pool    model.PoolName
+	backend model.BackendName
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		decisions: map[key]Decision{},
+	}
+}
+
+func (m *Manager) SetDecision(decision Decision) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.decisions[key{pool: decision.Pool, backend: decision.Backend}] = normalizeDecision(decision)
+}
+
+func (m *Manager) Decision(pool model.PoolName, backend model.BackendName) (Decision, bool) {
+	if m == nil {
+		return Decision{}, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	decision, ok := m.decisions[key{pool: pool, backend: backend}]
+	return decision, ok
+}
+
+func (m *Manager) Snapshot() []Decision {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]Decision, 0, len(m.decisions))
+	for _, decision := range m.decisions {
+		result = append(result, decision)
+	}
+	return result
+}
+
+func (m *Manager) MarkStale(staleAfter time.Duration, now time.Time) {
+	if m == nil || staleAfter <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for cacheKey, decision := range m.decisions {
+		if decision.UpdatedAt.IsZero() || now.Sub(decision.UpdatedAt) > staleAfter {
+			decision.Stale = true
+			if decision.State == "" {
+				decision.State = StateUnknown
+			}
+			m.decisions[cacheKey] = decision
+		}
+	}
+}
+
+func normalizeDecision(decision Decision) Decision {
+	if decision.State == "" {
+		decision.State = StateUnknown
+	}
+	if decision.Action == "" {
+		decision.Action = ActionDisable
+	}
+	return decision
+}

--- a/internal/tier/cache_test.go
+++ b/internal/tier/cache_test.go
@@ -1,0 +1,52 @@
+package tier
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+func TestManagerStoresAndMarksStaleDecisions(t *testing.T) {
+	manager := NewManager()
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	manager.SetDecision(Decision{
+		Pool:      model.PoolLite,
+		Backend:   model.BackendCodeBuild,
+		State:     StateHealthy,
+		Action:    ActionDisable,
+		UpdatedAt: now,
+	})
+
+	got, ok := manager.Decision(model.PoolLite, model.BackendCodeBuild)
+	if !ok {
+		t.Fatal("expected cached decision")
+	}
+	if got.State != StateHealthy {
+		t.Fatalf("unexpected state: %s", got.State)
+	}
+
+	manager.MarkStale(time.Minute, now.Add(2*time.Minute))
+	got, ok = manager.Decision(model.PoolLite, model.BackendCodeBuild)
+	if !ok || !got.Stale {
+		t.Fatalf("expected stale decision, got %+v", got)
+	}
+}
+
+func TestManagerConcurrentAccess(t *testing.T) {
+	manager := NewManager()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.SetDecision(Decision{Pool: model.PoolLite, Backend: model.BackendLambda, State: StateHealthy})
+			_, _ = manager.Decision(model.PoolLite, model.BackendLambda)
+		}()
+	}
+	wg.Wait()
+	if len(manager.Snapshot()) != 1 {
+		t.Fatalf("expected one cached decision, got %d", len(manager.Snapshot()))
+	}
+}

--- a/internal/tier/config_refresher.go
+++ b/internal/tier/config_refresher.go
@@ -1,0 +1,244 @@
+package tier
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/tier/promclient"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/tier/provider"
+)
+
+type SecretReader interface {
+	ReadSecret(context.Context, string) (map[string]string, error)
+}
+
+type ConfigRefresher struct {
+	cfg          model.BrokerConfig
+	secretReader SecretReader
+	providers    provider.Client
+	now          func() time.Time
+}
+
+func NewConfigRefresher(cfg model.BrokerConfig, secretReader SecretReader) *ConfigRefresher {
+	return &ConfigRefresher{
+		cfg:          cfg,
+		secretReader: secretReader,
+		providers:    provider.NewHTTPClient(resolvePrometheusTimeout(cfg.Broker.TierRouting.Prometheus.Timeout)),
+		now:          time.Now,
+	}
+}
+
+func (r *ConfigRefresher) Refresh(ctx context.Context) ([]Decision, error) {
+	if r == nil || !r.cfg.Broker.TierRouting.Enabled {
+		return nil, nil
+	}
+	now := r.now()
+	decisions := make([]Decision, 0)
+	var firstErr error
+	for _, pool := range r.cfg.Pools {
+		for backendName, backendCfg := range pool.Backends {
+			for _, ruleCfg := range backendCfg.TierRules {
+				decision, err := r.refreshRule(ctx, pool.Name, backendName, ruleCfg, now)
+				if err != nil && firstErr == nil {
+					firstErr = err
+				}
+				decisions = append(decisions, decision)
+			}
+		}
+	}
+	return decisions, firstErr
+}
+
+func (r *ConfigRefresher) refreshRule(ctx context.Context, pool model.PoolName, backendName model.BackendName, ruleCfg model.TierRuleConfig, now time.Time) (Decision, error) {
+	rule := Rule{
+		Name:               ruleCfg.Name,
+		Action:             normalizeAction(ruleCfg.Action),
+		SoftLimitRatio:     ruleCfg.SoftLimitRatio,
+		HardLimitRatio:     ruleCfg.HardLimitRatio,
+		MinRemainingCredit: ruleCfg.MinRemainingCredit,
+		ProjectionWindow:   ruleCfg.ProjectionWindow,
+		Combine:            CombineMostRestrictive,
+	}
+	snapshots := make([]SourceSnapshot, 0, 2)
+	var providerSnapshot SourceSnapshot
+	var firstErr error
+	if strings.TrimSpace(ruleCfg.ProviderRef) != "" {
+		var err error
+		providerSnapshot, err = r.providerSnapshot(ctx, ruleCfg.ProviderRef, now)
+		if err != nil {
+			firstErr = err
+			snapshots = append(snapshots, SourceSnapshot{
+				Source:    ruleCfg.ProviderRef,
+				UpdatedAt: now,
+				Err:       err.Error(),
+			})
+		} else {
+			snapshots = append(snapshots, providerSnapshot)
+		}
+	}
+
+	if strings.TrimSpace(ruleCfg.UsageQuery) != "" {
+		value, queryErr := r.prometheusValue(ctx, ruleCfg.UsageQuery)
+		if queryErr != nil {
+			if firstErr == nil {
+				firstErr = queryErr
+			}
+			snapshots = append(snapshots, SourceSnapshot{
+				Source:    "prometheus",
+				UpdatedAt: now,
+				Err:       queryErr.Error(),
+			})
+		} else if providerSnapshot.Limit > 0 || providerSnapshot.RemainingCredit > 0 {
+			providerSnapshot.Used = value
+			providerSnapshot.UpdatedAt = now
+			snapshots = replaceProviderSnapshot(snapshots, providerSnapshot)
+		} else {
+			snapshots = append(snapshots, SourceSnapshot{
+				Source:    "prometheus",
+				Limit:     1,
+				Used:      value,
+				UpdatedAt: now,
+			})
+		}
+	}
+
+	if strings.TrimSpace(ruleCfg.BurnRateQuery) != "" {
+		value, queryErr := r.prometheusValue(ctx, ruleCfg.BurnRateQuery)
+		if queryErr != nil {
+			if firstErr == nil {
+				firstErr = queryErr
+			}
+			snapshots = append(snapshots, SourceSnapshot{
+				Source:    "prometheus-burn-rate",
+				UpdatedAt: now,
+				Err:       queryErr.Error(),
+			})
+		} else if providerSnapshot.Limit > 0 || providerSnapshot.RemainingCredit > 0 {
+			providerSnapshot.BurnRate = value
+			providerSnapshot.UpdatedAt = now
+			snapshots = replaceProviderSnapshot(snapshots, providerSnapshot)
+		} else {
+			snapshots = append(snapshots, SourceSnapshot{
+				Source:    "prometheus-burn-rate",
+				Limit:     1,
+				BurnRate:  value,
+				UpdatedAt: now,
+			})
+		}
+	}
+
+	decision := Evaluate(EvaluationInput{
+		Pool:      pool,
+		Backend:   backendName,
+		Rule:      rule,
+		Snapshots: snapshots,
+		Now:       now,
+	})
+	return decision, firstErr
+}
+
+func (r *ConfigRefresher) providerSnapshot(ctx context.Context, ref string, now time.Time) (SourceSnapshot, error) {
+	providerCfg, ok := r.cfg.Broker.TierRouting.Providers[ref]
+	if !ok {
+		return SourceSnapshot{}, fmt.Errorf("provider ref %q is not configured", ref)
+	}
+	secret, err := r.readSecret(ctx, providerCfg.SecretRef)
+	if err != nil {
+		return SourceSnapshot{}, err
+	}
+	snapshotURL := strings.TrimSpace(secret["snapshot_url"])
+	if snapshotURL == "" {
+		snapshotURL = strings.TrimSpace(secret["url"])
+	}
+	if snapshotURL == "" {
+		return SourceSnapshot{}, fmt.Errorf("provider %q secret is missing snapshot_url", ref)
+	}
+	token := strings.TrimSpace(secret["token"])
+	if token == "" {
+		token = strings.TrimSpace(secret["bearer_token"])
+	}
+	snapshot, err := r.providers.Snapshot(ctx, provider.Request{
+		Provider: providerCfg.Provider,
+		Mode:     providerCfg.Mode,
+		URL:      snapshotURL,
+		Token:    token,
+		Source:   ref,
+	})
+	if err != nil {
+		return SourceSnapshot{}, err
+	}
+	if snapshot.UpdatedAt.IsZero() {
+		snapshot.UpdatedAt = now
+	}
+	return SourceSnapshot{
+		Source:          snapshot.Source,
+		Limit:           snapshot.Limit,
+		Used:            snapshot.Used,
+		RemainingCredit: snapshot.RemainingCredit,
+		WindowEnd:       snapshot.WindowEnd,
+		UpdatedAt:       snapshot.UpdatedAt,
+		Err:             snapshot.Err,
+	}, nil
+}
+
+func (r *ConfigRefresher) prometheusValue(ctx context.Context, query string) (float64, error) {
+	promCfg := r.cfg.Broker.TierRouting.Prometheus
+	token := ""
+	if strings.TrimSpace(promCfg.SecretRef) != "" {
+		secret, err := r.readSecret(ctx, promCfg.SecretRef)
+		if err != nil {
+			return 0, err
+		}
+		token = strings.TrimSpace(secret["bearer_token"])
+		if token == "" {
+			token = strings.TrimSpace(secret["token"])
+		}
+	}
+	client := promclient.Client{
+		BaseURL:     promCfg.URL,
+		BearerToken: token,
+		Timeout:     resolvePrometheusTimeout(promCfg.Timeout),
+	}
+	return client.QueryInstant(ctx, query)
+}
+
+func (r *ConfigRefresher) readSecret(ctx context.Context, ref string) (map[string]string, error) {
+	if strings.TrimSpace(ref) == "" {
+		return map[string]string{}, nil
+	}
+	if r.secretReader == nil {
+		return nil, fmt.Errorf("secret reader is not configured")
+	}
+	return r.secretReader.ReadSecret(ctx, ref)
+}
+
+func replaceProviderSnapshot(snapshots []SourceSnapshot, providerSnapshot SourceSnapshot) []SourceSnapshot {
+	for index, snapshot := range snapshots {
+		if snapshot.Source == providerSnapshot.Source {
+			snapshots[index] = providerSnapshot
+			return snapshots
+		}
+	}
+	return append(snapshots, providerSnapshot)
+}
+
+func normalizeAction(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case ActionObserveOnly:
+		return ActionObserveOnly
+	case ActionDeprioritize:
+		return ActionDeprioritize
+	default:
+		return ActionDisable
+	}
+}
+
+func resolvePrometheusTimeout(timeout time.Duration) time.Duration {
+	if timeout > 0 {
+		return timeout
+	}
+	return 2 * time.Second
+}

--- a/internal/tier/config_refresher_test.go
+++ b/internal/tier/config_refresher_test.go
@@ -1,0 +1,80 @@
+package tier
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+type staticSecretReader map[string]map[string]string
+
+func (s staticSecretReader) ReadSecret(_ context.Context, name string) (map[string]string, error) {
+	return s[name], nil
+}
+
+func TestConfigRefresherCombinesPrometheusUsageWithProviderLimit(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"limit":100,"used":0,"updated_at":"` + now.Format(time.RFC3339) + `"}`))
+	}))
+	defer providerServer.Close()
+	prometheusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer prom-token" {
+			t.Fatalf("unexpected prometheus auth header: %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1715097600,"96"]}}`))
+	}))
+	defer prometheusServer.Close()
+
+	refresher := NewConfigRefresher(model.BrokerConfig{
+		Broker: model.BrokerRuntimeConfig{
+			TierRouting: model.TierRoutingConfig{
+				Enabled: true,
+				Prometheus: model.TierPrometheusConfig{
+					URL:       prometheusServer.URL,
+					SecretRef: "prom",
+				},
+				Providers: map[string]model.TierProviderConfig{
+					"aws-main": {
+						Provider:  "aws",
+						Mode:      "free-tier",
+						SecretRef: "aws",
+					},
+				},
+			},
+		},
+		Pools: []model.PoolConfig{{
+			Name: model.PoolLite,
+			Backends: map[model.BackendName]model.BackendConfig{
+				model.BackendCodeBuild: {
+					TierRules: []model.TierRuleConfig{{
+						Name:           "codebuild-free-tier",
+						ProviderRef:    "aws-main",
+						UsageQuery:     "uecb:usage",
+						HardLimitRatio: 0.95,
+						Action:         ActionDisable,
+					}},
+				},
+			},
+		}},
+	}, staticSecretReader{
+		"aws":  {"snapshot_url": providerServer.URL, "token": "aws-token"},
+		"prom": {"bearer_token": "prom-token"},
+	})
+	refresher.now = func() time.Time { return now }
+
+	decisions, err := refresher.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh returned error: %v", err)
+	}
+	if len(decisions) != 1 {
+		t.Fatalf("expected one decision, got %d", len(decisions))
+	}
+	if decisions[0].State != StateExceeded {
+		t.Fatalf("expected exceeded decision, got %+v", decisions[0])
+	}
+}

--- a/internal/tier/evaluator.go
+++ b/internal/tier/evaluator.go
@@ -1,0 +1,138 @@
+package tier
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+func Evaluate(input EvaluationInput) Decision {
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	rule := normalizeRule(input.Rule)
+	decision := Decision{
+		Pool:      input.Pool,
+		Backend:   input.Backend,
+		State:     StateHealthy,
+		Action:    rule.Action,
+		UpdatedAt: now,
+	}
+	if len(input.Snapshots) == 0 {
+		decision.State = StateUnknown
+		decision.Reason = "no tier data"
+		return decision
+	}
+
+	state := StateHealthy
+	reasons := make([]string, 0)
+	usable := 0
+	for _, snapshot := range input.Snapshots {
+		if strings.TrimSpace(snapshot.Err) != "" {
+			decision.State = StateUnknown
+			decision.Reason = fmt.Sprintf("%s: %s", snapshot.Source, snapshot.Err)
+			return decision
+		}
+		if snapshot.UpdatedAt.IsZero() {
+			decision.State = StateUnknown
+			decision.Reason = fmt.Sprintf("%s: missing update timestamp", snapshot.Source)
+			return decision
+		}
+		usable++
+		sourceState, reason := evaluateSnapshot(rule, snapshot, now)
+		if moreRestrictive(sourceState, state) {
+			state = sourceState
+		}
+		if reason != "" {
+			reasons = append(reasons, reason)
+		}
+	}
+	if usable == 0 {
+		decision.State = StateUnknown
+		decision.Reason = "no usable tier data"
+		return decision
+	}
+	decision.State = state
+	decision.Reason = strings.Join(reasons, "; ")
+	return decision
+}
+
+func evaluateSnapshot(rule Rule, snapshot SourceSnapshot, now time.Time) (string, string) {
+	state := StateHealthy
+	reasons := make([]string, 0)
+	if snapshot.Limit > 0 {
+		ratio := snapshot.Used / snapshot.Limit
+		if rule.HardLimitRatio > 0 && ratio >= rule.HardLimitRatio {
+			state = StateExceeded
+		} else if rule.SoftLimitRatio > 0 && ratio >= rule.SoftLimitRatio {
+			state = StateApproaching
+		}
+		reasons = append(reasons, fmt.Sprintf("%s usage %.4g/%.4g", snapshot.Source, snapshot.Used, snapshot.Limit))
+		if projected, ok := projectedUsage(rule, snapshot, now); ok {
+			projectedRatio := projected / snapshot.Limit
+			if rule.HardLimitRatio > 0 && projectedRatio >= rule.HardLimitRatio && state != StateExceeded {
+				state = StateApproaching
+				reasons = append(reasons, fmt.Sprintf("%s projected usage %.4g/%.4g", snapshot.Source, projected, snapshot.Limit))
+			} else if rule.SoftLimitRatio > 0 && projectedRatio >= rule.SoftLimitRatio && state == StateHealthy {
+				state = StateApproaching
+				reasons = append(reasons, fmt.Sprintf("%s projected usage %.4g/%.4g", snapshot.Source, projected, snapshot.Limit))
+			}
+		}
+	}
+	if rule.MinRemainingCredit > 0 {
+		if snapshot.RemainingCredit < rule.MinRemainingCredit {
+			state = StateExceeded
+			reasons = append(reasons, fmt.Sprintf("%s remaining credit %.4g below %.4g", snapshot.Source, snapshot.RemainingCredit, rule.MinRemainingCredit))
+		}
+	}
+	if snapshot.Limit <= 0 && rule.MinRemainingCredit <= 0 {
+		return StateUnknown, fmt.Sprintf("%s: no limit or credit threshold", snapshot.Source)
+	}
+	if math.IsNaN(snapshot.Used) || math.IsNaN(snapshot.Limit) || math.IsNaN(snapshot.BurnRate) || math.IsNaN(snapshot.RemainingCredit) {
+		return StateUnknown, fmt.Sprintf("%s: invalid numeric value", snapshot.Source)
+	}
+	return state, strings.Join(reasons, ", ")
+}
+
+func projectedUsage(rule Rule, snapshot SourceSnapshot, now time.Time) (float64, bool) {
+	if snapshot.BurnRate <= 0 {
+		return 0, false
+	}
+	window := rule.ProjectionWindow
+	if window <= 0 && !snapshot.WindowEnd.IsZero() && snapshot.WindowEnd.After(now) {
+		window = snapshot.WindowEnd.Sub(now)
+	}
+	if window <= 0 {
+		return 0, false
+	}
+	return snapshot.Used + snapshot.BurnRate*window.Seconds(), true
+}
+
+func normalizeRule(rule Rule) Rule {
+	if rule.Action == "" {
+		rule.Action = ActionDisable
+	}
+	if rule.Combine == "" {
+		rule.Combine = CombineMostRestrictive
+	}
+	return rule
+}
+
+func moreRestrictive(candidate, current string) bool {
+	return restrictiveness(candidate) > restrictiveness(current)
+}
+
+func restrictiveness(state string) int {
+	switch state {
+	case StateExceeded:
+		return 3
+	case StateApproaching:
+		return 2
+	case StateUnknown:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/tier/evaluator_test.go
+++ b/internal/tier/evaluator_test.go
@@ -1,0 +1,113 @@
+package tier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+func TestEvaluateUsageThresholds(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		used float64
+		want string
+	}{
+		{name: "healthy", used: 70, want: StateHealthy},
+		{name: "approaching", used: 82, want: StateApproaching},
+		{name: "exceeded", used: 96, want: StateExceeded},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := Evaluate(EvaluationInput{
+				Pool:    model.PoolLite,
+				Backend: model.BackendCodeBuild,
+				Rule: Rule{
+					SoftLimitRatio: 0.8,
+					HardLimitRatio: 0.95,
+					Action:         ActionDisable,
+				},
+				Snapshots: []SourceSnapshot{{
+					Source:    "aws",
+					Limit:     100,
+					Used:      tc.used,
+					UpdatedAt: now,
+				}},
+				Now: now,
+			})
+			if decision.State != tc.want {
+				t.Fatalf("expected %s, got %+v", tc.want, decision)
+			}
+		})
+	}
+}
+
+func TestEvaluateCreditThresholdIsMostRestrictive(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	decision := Evaluate(EvaluationInput{
+		Pool:    model.PoolLite,
+		Backend: model.BackendCloudRun,
+		Rule: Rule{
+			SoftLimitRatio:     0.8,
+			HardLimitRatio:     0.95,
+			MinRemainingCredit: 5,
+			Action:             ActionDisable,
+		},
+		Snapshots: []SourceSnapshot{{
+			Source:          "gcp",
+			Limit:           100,
+			Used:            10,
+			RemainingCredit: 3,
+			UpdatedAt:       now,
+		}},
+		Now: now,
+	})
+	if decision.State != StateExceeded {
+		t.Fatalf("expected exceeded, got %+v", decision)
+	}
+}
+
+func TestEvaluateBurnRateProjectionApproachesLimit(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	decision := Evaluate(EvaluationInput{
+		Pool:    model.PoolLite,
+		Backend: model.BackendLambda,
+		Rule: Rule{
+			SoftLimitRatio:   0.8,
+			HardLimitRatio:   0.95,
+			ProjectionWindow: time.Hour,
+			Action:           ActionDeprioritize,
+		},
+		Snapshots: []SourceSnapshot{{
+			Source:    "aws",
+			Limit:     100,
+			Used:      70,
+			BurnRate:  0.01,
+			UpdatedAt: now,
+		}},
+		Now: now,
+	})
+	if decision.State != StateApproaching {
+		t.Fatalf("expected projected approaching state, got %+v", decision)
+	}
+}
+
+func TestEvaluateUnknownOnSourceError(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	decision := Evaluate(EvaluationInput{
+		Pool:    model.PoolLite,
+		Backend: model.BackendGCE,
+		Rule:    Rule{HardLimitRatio: 0.9},
+		Snapshots: []SourceSnapshot{{
+			Source:    "gcp",
+			Err:       "api unavailable",
+			UpdatedAt: now,
+		}},
+		Now: now,
+	})
+	if decision.State != StateUnknown {
+		t.Fatalf("expected unknown, got %+v", decision)
+	}
+}

--- a/internal/tier/promclient/client.go
+++ b/internal/tier/promclient/client.go
@@ -1,0 +1,131 @@
+package promclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	BaseURL     string
+	BearerToken string
+	Timeout     time.Duration
+	HTTPDoer    Doer
+}
+
+func (c *Client) QueryInstant(ctx context.Context, query string) (float64, error) {
+	if strings.TrimSpace(c.BaseURL) == "" {
+		return 0, fmt.Errorf("base url is required")
+	}
+
+	reqCtx := ctx
+	if c.Timeout > 0 {
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(ctx, c.Timeout)
+		defer cancel()
+	}
+
+	endpoint, err := url.Parse(strings.TrimRight(c.BaseURL, "/") + "/api/v1/query")
+	if err != nil {
+		return 0, err
+	}
+	values := endpoint.Query()
+	values.Set("query", query)
+	endpoint.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+	if token := strings.TrimSpace(c.BearerToken); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.doer().Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var payload response
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return 0, err
+	}
+	if payload.Status != "success" {
+		if payload.Error != "" {
+			return 0, fmt.Errorf("prometheus query failed: %s (%s)", payload.Error, payload.ErrorType)
+		}
+		return 0, fmt.Errorf("prometheus query failed: %s", resp.Status)
+	}
+
+	return payload.value()
+}
+
+func (c *Client) doer() Doer {
+	if c.HTTPDoer != nil {
+		return c.HTTPDoer
+	}
+	return &http.Client{Timeout: c.Timeout}
+}
+
+type response struct {
+	Status    string       `json:"status"`
+	ErrorType string       `json:"errorType"`
+	Error     string       `json:"error"`
+	Data      responseData `json:"data"`
+}
+
+type responseData struct {
+	ResultType string          `json:"resultType"`
+	Result     json.RawMessage `json:"result"`
+}
+
+func (r response) value() (float64, error) {
+	switch r.Data.ResultType {
+	case "scalar":
+		var result []any
+		if err := json.Unmarshal(r.Data.Result, &result); err != nil {
+			return 0, err
+		}
+		if len(result) != 2 {
+			return 0, fmt.Errorf("unexpected scalar result shape")
+		}
+		value, ok := result[1].(string)
+		if !ok {
+			return 0, fmt.Errorf("unexpected scalar value type")
+		}
+		return strconv.ParseFloat(value, 64)
+	case "vector":
+		var result []struct {
+			Value []json.RawMessage `json:"value"`
+		}
+		if err := json.Unmarshal(r.Data.Result, &result); err != nil {
+			return 0, err
+		}
+		if len(result) != 1 || len(result[0].Value) != 2 {
+			return 0, fmt.Errorf("expected a single-sample vector")
+		}
+		var value string
+		if err := json.Unmarshal(result[0].Value[1], &value); err != nil {
+			return 0, err
+		}
+		return strconv.ParseFloat(value, 64)
+	default:
+		return 0, fmt.Errorf("unsupported result type %q", r.Data.ResultType)
+	}
+}

--- a/internal/tier/promclient/client_test.go
+++ b/internal/tier/promclient/client_test.go
@@ -1,0 +1,76 @@
+package promclient
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQueryInstantParsesScalar(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("unexpected auth header: %q", got)
+		}
+		if got := r.URL.Query().Get("query"); got != "up" {
+			t.Fatalf("unexpected query: %q", got)
+		}
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"scalar","result":[1712345678.123,"12.5"]}}`)
+	}))
+	defer server.Close()
+
+	client := Client{BaseURL: server.URL, BearerToken: "token"}
+	value, err := client.QueryInstant(context.Background(), "up")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if value != 12.5 {
+		t.Fatalf("unexpected value: %v", value)
+	}
+}
+
+func TestQueryInstantParsesVector(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"runner"},"value":[1712345678.123,"7"]}]}}`)
+	}))
+	defer server.Close()
+
+	client := Client{BaseURL: server.URL}
+	value, err := client.QueryInstant(context.Background(), "up")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if value != 7 {
+		t.Fatalf("unexpected value: %v", value)
+	}
+}
+
+func TestQueryInstantReturnsErrorPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"error","errorType":"bad_data","error":"boom"}`)
+	}))
+	defer server.Close()
+
+	client := Client{BaseURL: server.URL}
+	_, err := client.QueryInstant(context.Background(), "up")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected error payload, got %v", err)
+	}
+}
+
+func TestQueryInstantAppliesTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"scalar","result":[1712345678.123,"1"]}}`)
+	}))
+	defer server.Close()
+
+	client := Client{BaseURL: server.URL, Timeout: 5 * time.Millisecond}
+	_, err := client.QueryInstant(context.Background(), "up")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}

--- a/internal/tier/provider/provider.go
+++ b/internal/tier/provider/provider.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	NameAWS   = "aws"
+	NameAzure = "azure"
+	NameGCP   = "gcp"
+
+	ModeFreeTier      = "free-tier"
+	ModeCostUsage     = "cost-usage"
+	ModeCredits       = "credits"
+	ModeBudget        = "budget"
+	ModeConsumption   = "consumption"
+	ModeBalance       = "balance"
+	ModeBillingExport = "billing-export"
+)
+
+type Request struct {
+	Provider string
+	Mode     string
+	URL      string
+	Token    string
+	Source   string
+}
+
+type Client interface {
+	Snapshot(context.Context, Request) (Snapshot, error)
+}
+
+type Snapshot struct {
+	Source          string
+	Limit           float64
+	Used            float64
+	BurnRate        float64
+	RemainingCredit float64
+	WindowEnd       time.Time
+	UpdatedAt       time.Time
+	Err             string
+}
+
+type HTTPClient struct {
+	client *http.Client
+}
+
+func NewHTTPClient(timeout time.Duration) *HTTPClient {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &HTTPClient{client: &http.Client{Timeout: timeout}}
+}
+
+func (c *HTTPClient) Snapshot(ctx context.Context, request Request) (Snapshot, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, request.URL, nil)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if token := strings.TrimSpace(request.Token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+		return Snapshot{}, fmt.Errorf("provider query failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return DecodeSnapshot(resp.Body, request.Source)
+}
+
+func DecodeSnapshot(reader io.Reader, source string) (Snapshot, error) {
+	var payload struct {
+		Source          string    `json:"source"`
+		Limit           float64   `json:"limit"`
+		Used            float64   `json:"used"`
+		BurnRate        float64   `json:"burn_rate"`
+		RemainingCredit float64   `json:"remaining_credit"`
+		WindowEnd       time.Time `json:"window_end"`
+		UpdatedAt       time.Time `json:"updated_at"`
+		Error           string    `json:"error"`
+	}
+	if err := json.NewDecoder(reader).Decode(&payload); err != nil {
+		return Snapshot{}, err
+	}
+	if payload.Source == "" {
+		payload.Source = source
+	}
+	return Snapshot{
+		Source:          payload.Source,
+		Limit:           payload.Limit,
+		Used:            payload.Used,
+		BurnRate:        payload.BurnRate,
+		RemainingCredit: payload.RemainingCredit,
+		WindowEnd:       payload.WindowEnd,
+		UpdatedAt:       payload.UpdatedAt,
+		Err:             payload.Error,
+	}, nil
+}
+
+func EncodeSnapshot(snapshot Snapshot) io.Reader {
+	payload := struct {
+		Source          string    `json:"source"`
+		Limit           float64   `json:"limit"`
+		Used            float64   `json:"used"`
+		BurnRate        float64   `json:"burn_rate"`
+		RemainingCredit float64   `json:"remaining_credit"`
+		WindowEnd       time.Time `json:"window_end"`
+		UpdatedAt       time.Time `json:"updated_at"`
+		Error           string    `json:"error,omitempty"`
+	}{
+		Source:          snapshot.Source,
+		Limit:           snapshot.Limit,
+		Used:            snapshot.Used,
+		BurnRate:        snapshot.BurnRate,
+		RemainingCredit: snapshot.RemainingCredit,
+		WindowEnd:       snapshot.WindowEnd,
+		UpdatedAt:       snapshot.UpdatedAt,
+		Error:           snapshot.Err,
+	}
+	data, _ := json.Marshal(payload)
+	return bytes.NewReader(data)
+}

--- a/internal/tier/provider/provider_test.go
+++ b/internal/tier/provider/provider_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPClientNormalizesSnapshotResponse(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("missing bearer token: %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"limit":100,"used":80,"remaining_credit":7,"updated_at":"` + now.Format(time.RFC3339) + `"}`))
+	}))
+	defer server.Close()
+
+	snapshot, err := NewHTTPClient(0).Snapshot(context.Background(), Request{
+		Provider: NameAWS,
+		Mode:     ModeFreeTier,
+		URL:      server.URL,
+		Token:    "token",
+		Source:   "aws-main",
+	})
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	if snapshot.Source != "aws-main" || snapshot.Limit != 100 || snapshot.Used != 80 || snapshot.RemainingCredit != 7 {
+		t.Fatalf("unexpected snapshot: %+v", snapshot)
+	}
+}
+
+func TestEncodeDecodeSnapshotRoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	want := Snapshot{
+		Source:          "gcp-main",
+		Limit:           10,
+		Used:            2,
+		RemainingCredit: 4,
+		UpdatedAt:       now,
+	}
+	got, err := DecodeSnapshot(EncodeSnapshot(want), "")
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if got.Source != want.Source || got.Limit != want.Limit || got.Used != want.Used || got.RemainingCredit != want.RemainingCredit {
+		t.Fatalf("unexpected round trip: %+v", got)
+	}
+}

--- a/internal/tier/refresh.go
+++ b/internal/tier/refresh.go
@@ -1,0 +1,51 @@
+package tier
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"time"
+)
+
+type Refresher interface {
+	Refresh(context.Context) ([]Decision, error)
+}
+
+func StartRefreshLoop(ctx context.Context, manager *Manager, refresher Refresher, interval time.Duration) {
+	if manager == nil || refresher == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	go func() {
+		timer := time.NewTimer(jitter(interval))
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				decisions, err := refresher.Refresh(ctx)
+				if err != nil {
+					log.Printf("tier refresh failed: %v", err)
+				}
+				for _, decision := range decisions {
+					manager.SetDecision(decision)
+				}
+				timer.Reset(jitter(interval))
+			}
+		}
+	}()
+}
+
+func jitter(interval time.Duration) time.Duration {
+	if interval <= time.Second {
+		return interval
+	}
+	maxJitter := int64(interval / 10)
+	if maxJitter <= 0 {
+		return interval
+	}
+	return interval + time.Duration(rand.Int63n(maxJitter))
+}

--- a/internal/tier/types.go
+++ b/internal/tier/types.go
@@ -1,0 +1,63 @@
+package tier
+
+import (
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+const (
+	StateHealthy     = "healthy"
+	StateApproaching = "approaching"
+	StateExceeded    = "exceeded"
+	StateUnknown     = "unknown"
+
+	ActionObserveOnly  = "observe-only"
+	ActionDeprioritize = "deprioritize"
+	ActionDisable      = "disable"
+
+	FailureModePassThrough = "pass-through-round-robin"
+	FailureModeBlock       = "block"
+	FailureModeFallback    = "fallback-backends"
+
+	CombineMostRestrictive = "most-restrictive"
+)
+
+type Decision struct {
+	Pool      model.PoolName
+	Backend   model.BackendName
+	State     string
+	Action    string
+	Reason    string
+	UpdatedAt time.Time
+	Stale     bool
+}
+
+type SourceSnapshot struct {
+	Source          string
+	Limit           float64
+	Used            float64
+	BurnRate        float64
+	RemainingCredit float64
+	WindowEnd       time.Time
+	UpdatedAt       time.Time
+	Err             string
+}
+
+type Rule struct {
+	Name               string
+	Action             string
+	SoftLimitRatio     float64
+	HardLimitRatio     float64
+	MinRemainingCredit float64
+	ProjectionWindow   time.Duration
+	Combine            string
+}
+
+type EvaluationInput struct {
+	Pool      model.PoolName
+	Backend   model.BackendName
+	Rule      Rule
+	Snapshots []SourceSnapshot
+	Now       time.Time
+}


### PR DESCRIPTION
## Summary

- adds cached tier-aware backend routing for Prometheus/provider free-tier, budget, and credit decisions
- supports pass-through, block, and fallback-backends failure modes with tier-aware warm-pool gating
- adds config validation, secret-ref discovery, Prometheus/provider adapters, observability metrics, docs, Helm defaults, and CI regression coverage

## Validation

- go.exe test ./internal/api -run "TestPinnedHealthyTierBackendStillReturnsCapacityErrorWhenFull|Test.*Tier" -count=1
- go.exe test ./internal/tier/... -count=1
- go.exe test ./internal/api ./internal/config ./internal/runtime -run "Test.*Tier" -count=1
- go.exe test ./...
- helm template uecb charts/unified-ephemeral-runner-broker
- kubectl kustomize examples/gitops/kustomize/base
- git diff --check
