### PR TITLE
Add archive tools to provider runner images

### DIFF
--- a/Dockerfile.azure-functions
+++ b/Dockerfile.azure-functions
@@ -18,7 +18,9 @@ RUN set -eux; \
     gzip \
     jq \
     tar \
+    xz-utils \
     unzip \
+    zstd \
     "${libicu_pkg}"; \
   curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
   apt-get install -y --no-install-recommends nodejs; \

--- a/Dockerfile.cloud-run
+++ b/Dockerfile.cloud-run
@@ -16,7 +16,9 @@ RUN apt-get update \
     libicu74 \
     python3 \
     tar \
+    xz-utils \
     unzip \
+    zstd \
   && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && node --version \

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -19,7 +19,9 @@ RUN apt-get update \
     python3 \
     python3-pip \
     tar \
+    xz-utils \
     unzip \
+    zstd \
   && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && node --version \

--- a/Dockerfile.launcher
+++ b/Dockerfile.launcher
@@ -11,7 +11,9 @@ RUN apt-get update \
     libicu74 \
     python3 \
     tar \
+    xz-utils \
     unzip \
+    zstd \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /bootstrap
 COPY docker/launcher/entrypoint.sh /bootstrap/entrypoint.sh

--- a/internal/imagecontracts/image_contracts_test.go
+++ b/internal/imagecontracts/image_contracts_test.go
@@ -36,6 +36,8 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 			"https://deb.nodesource.com/setup_${NODE_MAJOR}.x",
 			"UECB_PROVIDER=lambda",
 			"RUNNER_ALLOW_RUNASROOT=1",
+			"xz-utils",
+			"zstd",
 		},
 		"Dockerfile.cloud-run": {
 			"COPY docker/launcher/entrypoint.sh /bootstrap/entrypoint.sh",
@@ -44,6 +46,8 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 			"https://deb.nodesource.com/setup_${NODE_MAJOR}.x",
 			"UECB_PROVIDER=cloud-run",
 			"RUNNER_ALLOW_RUNASROOT=1",
+			"xz-utils",
+			"zstd",
 		},
 		"Dockerfile.azure-functions": {
 			"COPY docker/azure-functions/function_app.py /home/site/wwwroot/function_app.py",
@@ -51,6 +55,8 @@ func TestProviderImagesAreOwnedByRunnerRepo(t *testing.T) {
 			"nodejs",
 			"NODE_MAJOR=24",
 			"https://deb.nodesource.com/setup_${NODE_MAJOR}.x",
+			"xz-utils",
+			"zstd",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Bake xz-utils and zstd into launcher, cloud-run, lambda, and azure-functions runner images
- Add image contract coverage so provider images keep the archive tools needed by OpenTofu/setup actions

## Validation
- docker run --rm -v /mnt/c/Code/unified-ephemeral-runner-broker-worktrees/runtime-archive-deps:/src -w /src golang:1.24 go test ./...
- docker build -f Dockerfile.cloud-run -t uecb-cloud-run:archive-deps-test .
- docker run --rm --entrypoint /bin/bash uecb-cloud-run:archive-deps-test -lc 'command -v unzip && command -v xz && command -v zstd && node --version'