### PR TITLE
Use configured ARC runner labels

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	registry := backend.NewRegistry(
-		arcbackend.New(),
+		arcbackend.New(cfg),
 		codebuildbackend.New(cfg, secretReader),
 		lambdabackend.New(cfg, secretReader),
 		cloudbackend.New(cfg, secretReader),

--- a/internal/backend/arc/backend.go
+++ b/internal/backend/arc/backend.go
@@ -2,15 +2,18 @@ package arc
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
 
-type Backend struct{}
+type Backend struct {
+	cfg model.BrokerConfig
+}
 
-func New() *Backend {
-	return &Backend{}
+func New(cfg model.BrokerConfig) *Backend {
+	return &Backend{cfg: cfg}
 }
 
 func (b *Backend) Name() model.BackendName {
@@ -18,14 +21,40 @@ func (b *Backend) Name() model.BackendName {
 }
 
 func (b *Backend) Provision(_ context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	runnerLabel := b.runnerLabel(allocation.Pool, allocation.ID)
 	return backend.ProvisionedRunner{
-		RunnerLabel: backend.DefaultRunnerLabel(model.BackendARC, allocation.ID),
+		RunnerLabel: runnerLabel,
 		Metadata: map[string]string{
 			"pool":            string(request.Pool),
 			"capability":      "full",
 			"provisioner":     "arc-job",
 			"lifecycle":       "ephemeral",
+			"runner_label":    runnerLabel,
 			"supports_docker": "true",
 		},
 	}, nil
+}
+
+func (b *Backend) runnerLabel(poolName model.PoolName, allocationID string) string {
+	if cfg, ok := b.backendConfig(poolName); ok {
+		if runnerLabel := strings.TrimSpace(cfg.RunnerLabel); runnerLabel != "" {
+			return runnerLabel
+		}
+		if template := strings.TrimSpace(cfg.Template); template != "" {
+			return template
+		}
+	}
+
+	return backend.DefaultRunnerLabel(model.BackendARC, allocationID)
+}
+
+func (b *Backend) backendConfig(poolName model.PoolName) (model.BackendConfig, bool) {
+	for _, pool := range b.cfg.Pools {
+		if pool.Name != poolName {
+			continue
+		}
+		cfg, ok := pool.Backends[model.BackendARC]
+		return cfg, ok
+	}
+	return model.BackendConfig{}, false
 }

--- a/internal/backend/arc/backend_test.go
+++ b/internal/backend/arc/backend_test.go
@@ -1,0 +1,116 @@
+package arc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/config"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+func configureArcBackend(cfg model.BrokerConfig, poolName model.PoolName, mutate func(*model.BackendConfig)) model.BrokerConfig {
+	for index := range cfg.Pools {
+		if cfg.Pools[index].Name != poolName {
+			continue
+		}
+		backendCfg := cfg.Pools[index].Backends[model.BackendARC]
+		mutate(&backendCfg)
+		cfg.Pools[index].Backends[model.BackendARC] = backendCfg
+		break
+	}
+	return cfg
+}
+
+func TestProvisionReturnsConfiguredRunnerLabelAndUsefulMetadata(t *testing.T) {
+	cfg := configureArcBackend(config.Default(), model.PoolLite, func(backendCfg *model.BackendConfig) {
+		backendCfg.Enabled = true
+		backendCfg.RunnerLabel = "arc-scale-set"
+		backendCfg.Template = "arc-lite"
+	})
+
+	provisioned, err := New(cfg).Provision(context.Background(), model.AllocationRequest{
+		Pool: model.PoolLite,
+	}, model.AllocationStatus{
+		ID:   "arc-001",
+		Pool: model.PoolLite,
+	})
+	if err != nil {
+		t.Fatalf("provision failed: %v", err)
+	}
+
+	if got := provisioned.RunnerLabel; got != "arc-scale-set" {
+		t.Fatalf("expected configured runner label, got %q", got)
+	}
+
+	wantMetadata := map[string]string{
+		"pool":            string(model.PoolLite),
+		"capability":      "full",
+		"provisioner":     "arc-job",
+		"lifecycle":       "ephemeral",
+		"runner_label":    "arc-scale-set",
+		"supports_docker": "true",
+	}
+	for key, want := range wantMetadata {
+		if got := provisioned.Metadata[key]; got != want {
+			t.Fatalf("expected metadata %q=%q, got %q", key, want, got)
+		}
+	}
+}
+
+func TestProvisionFallsBackToTemplateThenGeneratedLabel(t *testing.T) {
+	t.Run("template", func(t *testing.T) {
+		cfg := configureArcBackend(config.Default(), model.PoolLite, func(backendCfg *model.BackendConfig) {
+			backendCfg.Enabled = true
+			backendCfg.RunnerLabel = ""
+			backendCfg.Template = "arc-lite-template"
+		})
+
+		provisioned, err := New(cfg).Provision(context.Background(), model.AllocationRequest{
+			Pool: model.PoolLite,
+		}, model.AllocationStatus{
+			ID:   "arc-002",
+			Pool: model.PoolLite,
+		})
+		if err != nil {
+			t.Fatalf("provision failed: %v", err)
+		}
+
+		if got := provisioned.RunnerLabel; got != "arc-lite-template" {
+			t.Fatalf("expected template fallback label, got %q", got)
+		}
+		if got := provisioned.Metadata["runner_label"]; got != "arc-lite-template" {
+			t.Fatalf("expected metadata runner_label to match template fallback, got %q", got)
+		}
+	})
+
+	t.Run("generated", func(t *testing.T) {
+		cfg := configureArcBackend(config.Default(), model.PoolLite, func(backendCfg *model.BackendConfig) {
+			backendCfg.Enabled = true
+			backendCfg.RunnerLabel = ""
+			backendCfg.Template = ""
+		})
+
+		provisioned, err := New(cfg).Provision(context.Background(), model.AllocationRequest{
+			Pool: model.PoolLite,
+		}, model.AllocationStatus{
+			ID:   "arc-003",
+			Pool: model.PoolLite,
+		})
+		if err != nil {
+			t.Fatalf("provision failed: %v", err)
+		}
+
+		defaultLabel := backend.DefaultRunnerLabel(model.BackendARC, "arc-003")
+		if got := provisioned.RunnerLabel; got != defaultLabel {
+			t.Fatalf("expected generated fallback label, got %q", got)
+		}
+		if got := provisioned.Metadata["runner_label"]; got != defaultLabel {
+			t.Fatalf("expected metadata runner_label to match generated label, got %q", got)
+		}
+		if !strings.HasPrefix(provisioned.RunnerLabel, "uecb-arc-") {
+			t.Fatalf("expected generated ARC label prefix, got %q", provisioned.RunnerLabel)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- pass broker config into the ARC backend
- return configured ARC runnerLabel, falling back to template and then synthetic labels
- add ARC backend tests for configured, template, and synthetic label behavior

## Validation
- powershell.exe -NoProfile -Command "Set-Location 'C:\Code\unified-ephemeral-runner-broker-worktrees\arc-runner-label-fix'; & 'C:\Program Files\Go\bin\go.exe' test ./internal/backend/arc ./internal/api ./cmd/broker"
- powershell.exe -NoProfile -Command "Set-Location 'C:\Code\unified-ephemeral-runner-broker-worktrees\arc-runner-label-fix'; & 'C:\Program Files\Go\bin\go.exe' test ./..."