### PR TITLE
Allow Lambda fallback past rate-limited CodeBuild

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -102,7 +102,8 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		return model.AllocationStatus{}, err
 	}
 	resultPool = pool.Name
-	request.Backend = s.resolveRequestedBackend(pool, request.Backend)
+	var fallbackSyntheticBackendPin bool
+	request.Backend, fallbackSyntheticBackendPin = s.resolveRequestedBackend(pool, request.Backend)
 
 	explicitTimeout := request.JobTimeout > 0
 	timeout := request.JobTimeout
@@ -121,9 +122,17 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 			return model.AllocationStatus{}, err
 		}
 	}
+	admissionInputPool := pool
 	pool, err = s.filterBackendsByAdmission(pool, request)
 	if err != nil {
-		return model.AllocationStatus{}, err
+		if !fallbackSyntheticBackendPin || !errors.Is(err, ErrBackendRateLimited) && !errors.Is(err, ErrBackendCircuitOpen) {
+			return model.AllocationStatus{}, err
+		}
+		request.Backend = nil
+		pool, err = s.filterBackendsByAdmission(admissionInputPool, request)
+		if err != nil {
+			return model.AllocationStatus{}, err
+		}
 	}
 	pool, err = s.filterBackendsByTierState(pool, request)
 	if err != nil {
@@ -132,7 +141,14 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 
 	selected, err := s.reserve(pool, request)
 	if err != nil {
-		return model.AllocationStatus{}, err
+		if !fallbackSyntheticBackendPin || request.Backend == nil || !errors.Is(err, scheduler.ErrNoCapacity) {
+			return model.AllocationStatus{}, err
+		}
+		request.Backend = nil
+		selected, err = s.reserve(pool, request)
+		if err != nil {
+			return model.AllocationStatus{}, err
+		}
 	}
 	if s.admission != nil {
 		decision := s.admission.allow(pool.Name, selected, pool.Backends[selected], s.now(), false, true)
@@ -1084,21 +1100,21 @@ func (s *Service) resolvePool(name model.PoolName) (model.PoolConfig, error) {
 	return model.PoolConfig{}, ErrUnknownPool
 }
 
-func (s *Service) resolveRequestedBackend(pool model.PoolConfig, requested *model.BackendName) *model.BackendName {
+func (s *Service) resolveRequestedBackend(pool model.PoolConfig, requested *model.BackendName) (*model.BackendName, bool) {
 	if requested == nil {
-		return nil
+		return nil, false
 	}
 	if *requested != model.BackendLambda {
-		return requested
+		return requested, false
 	}
 
 	lambdaCfg, hasLambda := pool.Backends[model.BackendLambda]
 	codebuildCfg, hasCodebuild := pool.Backends[model.BackendCodeBuild]
 	if (!hasLambda || !lambdaCfg.Enabled) && hasCodebuild && codebuildCfg.Enabled {
 		backend := model.BackendCodeBuild
-		return &backend
+		return &backend, true
 	}
-	return requested
+	return requested, false
 }
 
 func (s *Service) schedulerForPool(pool model.PoolConfig) scheduler.Scheduler {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -667,6 +667,61 @@ func TestRateLimitAppliesToSelectedColdBackendOnly(t *testing.T) {
 	}
 }
 
+func TestDisabledLambdaFallbackSkipsRateLimitedCodeBuild(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		arcCfg := pool.Backends[model.BackendARC]
+		arcCfg.Enabled = true
+		arcCfg.Healthy = true
+		arcCfg.MaxRunners = 1
+		pool.Backends[model.BackendARC] = arcCfg
+
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 1
+		codebuildCfg.RateLimit.Enabled = true
+		codebuildCfg.RateLimit.Permits = 1
+		codebuildCfg.RateLimit.Interval = time.Hour
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	})
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+
+	pinnedLambda := model.BackendLambda
+	first, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		Backend:    &pinnedLambda,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("first lambda fallback allocation failed: %v", err)
+	}
+	if first.SelectedBackend != model.BackendCodeBuild {
+		t.Fatalf("expected disabled lambda to prefer codebuild, got %s", first.SelectedBackend)
+	}
+	if _, ok := service.Cancel(first.ID); !ok {
+		t.Fatal("cancel failed")
+	}
+
+	second, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		Backend:    &pinnedLambda,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("expected rate-limited codebuild fallback allocation to succeed: %v", err)
+	}
+	if second.SelectedBackend != model.BackendARC {
+		t.Fatalf("expected arc fallback after codebuild rate limit, got %s", second.SelectedBackend)
+	}
+}
+
 func TestHalfOpenAdmissionDoesNotConsumeProbeSlotDuringFiltering(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {


### PR DESCRIPTION
## Summary
- preserve the Lambda-to-CodeBuild preference when Lambda is disabled
- clear that synthetic pin when CodeBuild is admission-blocked or full so normal fallback routing can pick another backend
- add regression coverage for disabled Lambda requests after CodeBuild rate limits are consumed

## Validation
- go.exe test ./internal/api
- go.exe test ./...
- bash scripts/audit_public_repo.sh