### PR TITLE
[codex] Add adapter SDK durable state and queued admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,34 @@ jobs:
             -run "Test.*Circuit|Test.*Breaker|Test.*Probe|Test.*Timeout|Test.*RateLimit" \
             -count=1
 
+  adapter-sdk-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Adapter SDK conformance tests
+        run: |
+          go test ./pkg/... ./examples/adapter/... -count=1
+
+  durable-state-queue-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Durable state and queue regression tests
+        run: |
+          go test ./internal/api ./internal/config ./internal/store \
+            -run "Test.*FileStore|Test.*Queue|Test.*Queued|Test.*StateStore" \
+            -count=1
+
   tier-routing-regression:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Built-in schedulers:
 
 - A Kubernetes broker service with a small REST API
 - A reusable GitHub Action, `allocate-runner`
+- A public backend adapter SDK with a conformance test harness
 - An OCI Helm chart for installation
 - Generic provider runner images for `launcher`, `lambda`, `cloud-run`, and `azure-functions`
 - A generic Kustomize-facing GitOps consumption path
@@ -152,6 +153,39 @@ broker:
 - `enabled: false` (default): active stale allocations move directly to `expired`.
 - `enabled: true`: active stale allocations move to `quarantined` for `quarantineTTL` (or immediately when `0`), then to `expired`.
 
+### Durable State Store
+
+The broker keeps allocation state in memory by default. Environments that need
+restart recovery can opt into a file-backed state store on a persistent volume.
+
+```yaml
+broker:
+  stateStore:
+    type: file
+    path: /var/lib/uecb/allocations.json
+```
+
+On startup, active `reserved`, `ready`, and `warm` allocations are rehydrated
+into scheduler accounting so a restarted broker does not over-admit capacity.
+
+### Queued Admission
+
+Queued admission is disabled by default. When enabled, retryable allocation
+failures such as no capacity, backend rate limiting, open backend circuits, or
+transient provider dispatch failures are stored as `pending` allocations.
+
+```yaml
+broker:
+  queue:
+    enabled: true
+    retryAfter: 30s
+    maxAttempts: 3
+```
+
+`POST /v1/allocations` returns `202 Accepted` with `state: pending` and a
+`Retry-After` header for queued allocations. The `allocate-runner` action polls
+the allocation until it becomes `ready` or `queue_wait_timeout` expires.
+
 ## Project Layout
 
 - `cmd/broker`: broker entrypoint
@@ -163,6 +197,7 @@ broker:
 - `examples/`: generic Terraform and GitOps consumption examples
 - `docs/`: architecture and security notes
 - `observability/`: reusable Prometheus alert rules and Grafana dashboard artifacts
+- `pkg/adapter`: public backend adapter SDK and conformance test helpers
 
 ## Public CI and Private Release Boundary
 

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: Skip OIDC and call the broker without a bearer token
     required: false
     default: "false"
+  queue_wait_timeout:
+    description: How long to poll a pending queued allocation before failing, for example 5m
+    required: false
+    default: 5m
 
 outputs:
   allocation_id:
@@ -75,6 +79,7 @@ runs:
         INPUT_EXCLUDED_CAPABILITIES: ${{ inputs.excluded_capabilities }}
         INPUT_OIDC_AUDIENCE: ${{ inputs.oidc_audience }}
         INPUT_ALLOW_UNAUTHENTICATED: ${{ inputs.allow_unauthenticated }}
+        INPUT_QUEUE_WAIT_TIMEOUT: ${{ inputs.queue_wait_timeout }}
       run: |
         set -euo pipefail
 
@@ -129,8 +134,58 @@ PY
 
         response="$(curl -fsSL "${auth_args[@]}" -H "Content-Type: application/json" -d "${request_body}" "${INPUT_BROKER_URL%/}/v1/allocations")"
 
+        deadline="$(python - <<'PY'
+import os
+import re
+import time
+
+value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
+match = re.fullmatch(r"(\d+)([smh]?)", value)
+if not match:
+    raise SystemExit(f"invalid queue_wait_timeout {value!r}")
+amount = int(match.group(1))
+unit = match.group(2) or "s"
+multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
+print(int(time.time()) + amount * multiplier)
+PY
+)"
+
+        while [ "$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin).get('state',''))")" = "pending" ]; do
+          now="$(date +%s)"
+          if [ "${now}" -ge "${deadline}" ]; then
+            echo "Timed out waiting for queued allocation to become ready." >&2
+            printf '%s\n' "${response}" >&2
+            exit 1
+          fi
+          allocation_id="$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['allocation_id'])")"
+          retry_after="$(printf '%s' "${response}" | python - <<'PY'
+import datetime
+import json
+import sys
+
+payload = json.load(sys.stdin)
+value = payload.get("retry_after")
+if not value:
+    print(5)
+    raise SystemExit
+dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+now = datetime.datetime.now(datetime.timezone.utc)
+seconds = int((dt - now).total_seconds())
+print(max(1, min(seconds, 30)))
+PY
+)"
+          sleep "${retry_after}"
+          response="$(curl -fsSL "${auth_args[@]}" "${INPUT_BROKER_URL%/}/v1/allocations/${allocation_id}")"
+        done
+
+        state="$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin).get('state',''))")"
+        if [ "${state}" != "ready" ] && [ "${state}" != "" ]; then
+          echo "Allocation did not become ready. Final state: ${state}" >&2
+          printf '%s\n' "${response}" >&2
+          exit 1
+        fi
+
         echo "allocation_id=$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['allocation_id'])")" >> "${GITHUB_OUTPUT}"
         echo "runner_label=$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['runner_label'])")" >> "${GITHUB_OUTPUT}"
         echo "selected_backend=$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['selected_backend'])")" >> "${GITHUB_OUTPUT}"
         echo "expires_at=$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['expires_at'])")" >> "${GITHUB_OUTPUT}"
-

--- a/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
+++ b/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
@@ -18,6 +18,15 @@ data:
       orphanCleanup:
         enabled: {{ .Values.config.broker.orphanCleanup.enabled }}
         quarantineTTL: {{ .Values.config.broker.orphanCleanup.quarantineTTL }}
+      stateStore:
+        type: {{ .Values.config.broker.stateStore.type }}
+        {{- if .Values.config.broker.stateStore.path }}
+        path: {{ .Values.config.broker.stateStore.path }}
+        {{- end }}
+      queue:
+        enabled: {{ .Values.config.broker.queue.enabled }}
+        retryAfter: {{ .Values.config.broker.queue.retryAfter }}
+        maxAttempts: {{ .Values.config.broker.queue.maxAttempts }}
       allowUnauthenticated: {{ .Values.config.allowUnauthenticated }}
       api:
         oidcAudience: {{ .Values.config.broker.api.oidcAudience }}

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -54,6 +54,13 @@ config:
     orphanCleanup:
       enabled: false
       quarantineTTL: 15m
+    stateStore:
+      type: memory
+      path: ""
+    queue:
+      enabled: false
+      retryAfter: 30s
+      maxAttempts: 3
     api:
       oidcAudience: uecb-broker
     tierRouting:

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -96,6 +96,14 @@ func main() {
 		}
 	}()
 
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for now := range ticker.C {
+			service.ReconcileQueue(context.Background(), now)
+		}
+	}()
+
 	if tierManager != nil {
 		go func() {
 			ticker := time.NewTicker(30 * time.Second)

--- a/docs/adapter-sdk.md
+++ b/docs/adapter-sdk.md
@@ -1,0 +1,40 @@
+# Backend Adapter SDK
+
+The public adapter SDK lives under `pkg/adapter`.
+
+It is for provider-owned runner controllers that want to implement the broker
+adapter lifecycle without depending on internal broker packages.
+
+## Lifecycle
+
+Adapters implement:
+
+- `Health`: report whether the backend can accept runner work.
+- `Capacity`: report active, pending, warm, and maximum runner counts.
+- `Reserve`: reserve a runner slot and return the runner label contract.
+- `Launch`: start or attach the runner execution.
+- `Cleanup`: release provider-side resources after a terminal allocation state.
+
+The conformance harness in `pkg/adapter/adaptertest` validates that an adapter
+honors the minimum lifecycle contract.
+
+```go
+func TestAdapterConformance(t *testing.T) {
+    adaptertest.RunConformance(t, func(testing.TB) adapter.Adapter {
+        return myadapter.New()
+    }, adaptertest.Options{})
+}
+```
+
+See `examples/adapter/mock` for a minimal reference implementation.
+
+## Compatibility
+
+The SDK follows the module version. Minor versions may add optional fields to
+request or result structs. Existing interface methods are kept stable within a
+minor line. Breaking interface changes require a new major module version.
+
+Generic HTTP dispatch backends remain the lowest-friction integration path. A
+conformant SDK adapter can sit behind that dispatch controller without requiring
+broker core changes for normal reserve, launch, health, capacity, and cleanup
+behavior.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@
 - The action exchanges OIDC identity for a broker allocation request.
 - The broker selects a backend, reserves capacity, provisions a runner, and returns the label that the heavy job should target.
 - External backends read `dispatch_url` and optional `dispatch_token` from their configured `secretRef` and hand off provisioning to a provider-owned controller.
+- Provider-owned controllers can use the public `pkg/adapter` SDK and `pkg/adapter/adaptertest` conformance harness to keep health, capacity, reserve, launch, and cleanup behavior aligned with the broker contract.
 
 ## Data Plane
 
@@ -29,6 +30,25 @@ Each pool backend may define a warm policy:
 The broker keeps warm allocations in the background when enabled and recycles them on TTL expiry or policy violations. Allocation requests consume warm capacity first when available, then fallback to cold launch.
 
 Warm capacity currently applies only to external dispatch backends and intentionally excludes `arc` and `azure-vm`.
+
+## State And Restart Recovery
+
+The default state store is in-memory. A file-backed state store can persist
+allocation records to a mounted volume for restart recovery.
+
+On service startup, the broker rehydrates scheduler accounting from persisted
+`reserved`, `ready`, and `warm` allocations. Pending allocations remain queued
+and are retried by the queue reconciler when their `retryAfter` time is reached.
+
+## Queued Admission
+
+Queued admission is optional and disabled by default.
+
+When enabled, the broker stores retryable allocation failures as `pending`
+instead of failing the workflow immediately. Retryable failures include
+temporary provider dispatch errors, rate-limited backends, open backend
+circuits, and short capacity gaps. The queue reconciler retries pending
+allocations until they become `ready`, expire, or exhaust `maxAttempts`.
 
 ## Pools
 

--- a/examples/adapter/mock/adapter.go
+++ b/examples/adapter/mock/adapter.go
@@ -1,0 +1,80 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/pkg/adapter"
+)
+
+type Adapter struct {
+	mu           sync.Mutex
+	maxRunners   int
+	reservations map[string]adapter.Reservation
+}
+
+func New(maxRunners int) *Adapter {
+	if maxRunners <= 0 {
+		maxRunners = 1
+	}
+	return &Adapter{
+		maxRunners:   maxRunners,
+		reservations: map[string]adapter.Reservation{},
+	}
+}
+
+func (a *Adapter) Health(context.Context) (adapter.HealthStatus, error) {
+	return adapter.HealthStatus{Healthy: true, Checked: time.Now().UTC()}, nil
+}
+
+func (a *Adapter) Capacity(context.Context) (adapter.CapacityStatus, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return adapter.CapacityStatus{
+		MaxRunners:    a.maxRunners,
+		ActiveRunners: len(a.reservations),
+	}, nil
+}
+
+func (a *Adapter) Reserve(_ context.Context, request adapter.ReservationRequest) (adapter.Reservation, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if len(a.reservations) >= a.maxRunners {
+		return adapter.Reservation{}, fmt.Errorf("mock adapter capacity exhausted")
+	}
+
+	id := request.AllocationID
+	if id == "" {
+		id = fmt.Sprintf("mock-%d", len(a.reservations)+1)
+	}
+	reservation := adapter.Reservation{
+		AllocationID: id,
+		RunnerName:   "uecb-mock-" + id,
+		RunnerLabel:  "uecb-mock-" + id,
+		ExpiresAt:    time.Now().UTC().Add(request.JobTimeout),
+		Metadata: map[string]string{
+			"adapter": "mock",
+		},
+	}
+	a.reservations[id] = reservation
+	return reservation, nil
+}
+
+func (a *Adapter) Launch(_ context.Context, request adapter.LaunchRequest) (adapter.LaunchResult, error) {
+	return adapter.LaunchResult{
+		RunnerLabel: request.Reservation.RunnerLabel,
+		Metadata: map[string]string{
+			"launch_mode": "cold",
+		},
+	}, nil
+}
+
+func (a *Adapter) Cleanup(_ context.Context, request adapter.CleanupRequest) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.reservations, request.Reservation.AllocationID)
+	return nil
+}

--- a/examples/adapter/mock/adapter_test.go
+++ b/examples/adapter/mock/adapter_test.go
@@ -1,0 +1,14 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/pkg/adapter"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/pkg/adapter/adaptertest"
+)
+
+func TestAdapterConformance(t *testing.T) {
+	adaptertest.RunConformance(t, func(testing.TB) adapter.Adapter {
+		return New(1)
+	}, adaptertest.Options{})
+}

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -77,10 +80,28 @@ func (s *Server) handleAllocations(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusBadRequest, err)
 			return
 		}
+		if allocation.State == model.StatePending {
+			if !allocation.RetryAfter.IsZero() {
+				w.Header().Set("Retry-After", retryAfterSeconds(allocation.RetryAfter, time.Now()))
+			}
+			s.writeJSON(w, http.StatusAccepted, allocation)
+			return
+		}
 		s.writeJSON(w, http.StatusCreated, allocation)
 	default:
 		s.writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
 	}
+}
+
+func retryAfterSeconds(retryAfter time.Time, now time.Time) string {
+	if !retryAfter.After(now) {
+		return "0"
+	}
+	seconds := int(retryAfter.Sub(now).Seconds())
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.Itoa(seconds)
 }
 
 func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -77,6 +77,46 @@ func TestHandleAllocationsAcceptsStringJobTimeout(t *testing.T) {
 	}
 }
 
+func TestHandleAllocationsReturnsAcceptedForQueuedAllocation(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.Queue.Enabled = true
+		cfg.Broker.Queue.RetryAfter = time.Second
+		cfg.Pools[0].Backends[model.BackendARC] = model.BackendConfig{
+			Enabled:    true,
+			Healthy:    true,
+			MaxRunners: 1,
+			Template:   "arc-full",
+		}
+	})
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+	server := newTestServer(t, service)
+	handler := server.Handler()
+
+	first := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	firstRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(firstRecorder, first)
+	if firstRecorder.Code != http.StatusCreated {
+		t.Fatalf("expected first allocation to succeed, got %d: %s", firstRecorder.Code, firstRecorder.Body.String())
+	}
+
+	second := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	secondRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(secondRecorder, second)
+	if secondRecorder.Code != http.StatusAccepted {
+		t.Fatalf("expected queued allocation to return 202, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
+	}
+	if secondRecorder.Header().Get("Retry-After") == "" {
+		t.Fatalf("expected Retry-After header for queued allocation")
+	}
+	var allocation model.AllocationStatus
+	if err := json.NewDecoder(secondRecorder.Body).Decode(&allocation); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if allocation.State != model.StatePending {
+		t.Fatalf("expected pending state, got %+v", allocation)
+	}
+}
+
 func TestMetricsExposeAllocationSignals(t *testing.T) {
 	service := newServiceWithConfig(nil)
 	server := newTestServer(t, service)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -37,7 +37,7 @@ type Service struct {
 	registry  *backend.Registry
 	scheds    *scheduler.Registry
 	fairShare *scheduler.PriorityFairShare
-	store     *store.Memory
+	store     store.Store
 	observer  Observer
 	admission *backendAdmission
 	tierMgr   *tier.Manager
@@ -52,19 +52,24 @@ func NewService(cfg model.BrokerConfig, registry *backend.Registry, health func(
 		health = func(context.Context) error { return nil }
 	}
 	schedulerRegistry := scheduler.NewRegistry()
-	return &Service{
+	stateStore, storeErr := store.NewFromConfig(cfg.Broker.StateStore)
+	if stateStore == nil {
+		stateStore = store.NewMemory()
+	}
+	service := &Service{
 		cfg:       cfg,
 		registry:  registry,
 		scheds:    schedulerRegistry,
 		fairShare: scheduler.NewPriorityFairShare(),
-		store:     store.NewMemory(),
+		store:     stateStore,
 		observer:  noopObserver{},
 		admission: newBackendAdmission(),
 		tierMgr:   tier.NewManager(),
-		initErr:   validateSchedulers(cfg.Pools, schedulerRegistry),
 		health:    health,
 		now:       time.Now,
 	}
+	service.initErr = firstErr(storeErr, validateSchedulers(cfg.Pools, schedulerRegistry), service.rehydrateSchedulerState())
+	return service
 }
 
 func (s *Service) SetTierManager(manager *tier.Manager) {
@@ -79,7 +84,49 @@ func (s *Service) SetObserver(observer Observer) {
 	s.observer = observer
 }
 
+func firstErr(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) rehydrateSchedulerState() error {
+	if s.store == nil {
+		return nil
+	}
+	for _, status := range s.store.List() {
+		if !isSchedulerAccountedState(status.State) {
+			continue
+		}
+		pool, err := s.resolvePool(status.Pool)
+		if err != nil {
+			return fmt.Errorf("rehydrate allocation %s: %w", status.ID, err)
+		}
+		selected := status.SelectedBackend
+		if selected == "" {
+			return fmt.Errorf("rehydrate allocation %s: selected backend is empty", status.ID)
+		}
+		request := model.AllocationRequest{
+			Pool:          status.Pool,
+			Backend:       &selected,
+			Tenant:        status.Tenant,
+			PriorityClass: status.PriorityClass,
+		}
+		if _, err := s.reserve(pool, request); err != nil {
+			return fmt.Errorf("rehydrate allocation %s on backend %s: %w", status.ID, selected, err)
+		}
+	}
+	return nil
+}
+
 func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest) (model.AllocationStatus, error) {
+	return s.allocateNow(ctx, request, model.AllocationStatus{})
+}
+
+func (s *Service) allocateNow(ctx context.Context, request model.AllocationRequest, existing model.AllocationStatus) (model.AllocationStatus, error) {
 	started := s.now()
 	resultPool := request.Pool
 	var resultBackend model.BackendName
@@ -114,11 +161,19 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 
 	pool, err = filterEligibleBackends(pool, request)
 	if err != nil {
+		if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
+			result = "queued"
+			return queued, nil
+		}
 		return model.AllocationStatus{}, err
 	}
 	if explicitTimeout {
 		pool, err = filterBackendsByTimeout(pool, request)
 		if err != nil {
+			if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
+				result = "queued"
+				return queued, nil
+			}
 			return model.AllocationStatus{}, err
 		}
 	}
@@ -126,27 +181,47 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	pool, err = s.filterBackendsByAdmission(pool, request)
 	if err != nil {
 		if !fallbackSyntheticBackendPin || !errors.Is(err, ErrBackendRateLimited) && !errors.Is(err, ErrBackendCircuitOpen) {
+			if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
+				result = "queued"
+				return queued, nil
+			}
 			return model.AllocationStatus{}, err
 		}
 		request.Backend = nil
 		pool, err = s.filterBackendsByAdmission(admissionInputPool, request)
 		if err != nil {
+			if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
+				result = "queued"
+				return queued, nil
+			}
 			return model.AllocationStatus{}, err
 		}
 	}
 	pool, err = s.filterBackendsByTierState(pool, request)
 	if err != nil {
+		if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
+			result = "queued"
+			return queued, nil
+		}
 		return model.AllocationStatus{}, err
 	}
 
 	selected, err := s.reserve(pool, request)
 	if err != nil {
 		if !fallbackSyntheticBackendPin || request.Backend == nil || !errors.Is(err, scheduler.ErrNoCapacity) {
+			if queued, ok := s.queueAllocation(ctx, request, pool.Name, "", err, existing); ok {
+				result = "queued"
+				return queued, nil
+			}
 			return model.AllocationStatus{}, err
 		}
 		request.Backend = nil
 		selected, err = s.reserve(pool, request)
 		if err != nil {
+			if queued, ok := s.queueAllocation(ctx, request, pool.Name, "", err, existing); ok {
+				result = "queued"
+				return queued, nil
+			}
 			return model.AllocationStatus{}, err
 		}
 	}
@@ -157,11 +232,26 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 			s.observer.ObserveBackendAdmissionRejected(pool.Name, selected, decision.Reason)
 			switch decision.Reason {
 			case "circuit-open":
-				return model.AllocationStatus{}, fmt.Errorf("selected backend %q is not admissible: %w", selected, ErrBackendCircuitOpen)
+				err := fmt.Errorf("selected backend %q is not admissible: %w", selected, ErrBackendCircuitOpen)
+				if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, existing); ok {
+					result = "queued"
+					return queued, nil
+				}
+				return model.AllocationStatus{}, err
 			case "rate-limited":
-				return model.AllocationStatus{}, fmt.Errorf("selected backend %q is not admissible: %w", selected, ErrBackendRateLimited)
+				err := fmt.Errorf("selected backend %q is not admissible: %w", selected, ErrBackendRateLimited)
+				if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, existing); ok {
+					result = "queued"
+					return queued, nil
+				}
+				return model.AllocationStatus{}, err
 			default:
-				return model.AllocationStatus{}, fmt.Errorf("selected backend %q is not admissible: %s", selected, decision.Reason)
+				err := fmt.Errorf("selected backend %q is not admissible: %s", selected, decision.Reason)
+				if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, existing); ok {
+					result = "queued"
+					return queued, nil
+				}
+				return model.AllocationStatus{}, err
 			}
 		}
 	}
@@ -172,18 +262,7 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 		"backend": string(selected),
 	})
 
-	allocation := model.AllocationStatus{
-		ID:              newID(),
-		CorrelationID:   correlationIDFromContext(ctx),
-		Pool:            pool.Name,
-		SelectedBackend: selected,
-		Tenant:          request.Tenant,
-		PriorityClass:   request.PriorityClass,
-		RequestedLabels: append([]string(nil), request.Labels...),
-		Metadata:        map[string]string{backend.MetadataLaunchModeKey: launchModeCold},
-		ExpiresAt:       s.now().Add(timeout),
-		State:           model.StateReserved,
-	}
+	allocation := s.prepareAllocation(ctx, request, existing, pool.Name, selected, timeout)
 
 	s.store.Save(allocation)
 
@@ -229,8 +308,12 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	s.observer.ObserveRegistrationLatency(pool.Name, selected, launchLatency)
 	if err != nil {
 		s.release(context.Background(), pool, selected, allocation)
-		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), err.Error())
 		s.recordBackendFailure(pool, selected, err, s.now())
+		if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, allocation); ok {
+			result = "queued"
+			return queued, nil
+		}
+		s.store.MarkState(allocation.ID, model.StateFailed, s.now(), err.Error())
 		logAllocationEvent(ctx, "allocation_failed", map[string]string{
 			"allocation_id": allocation.ID,
 			"pool":          string(pool.Name),
@@ -257,6 +340,118 @@ func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest)
 	})
 
 	return allocation, nil
+}
+
+func (s *Service) prepareAllocation(ctx context.Context, request model.AllocationRequest, existing model.AllocationStatus, pool model.PoolName, selected model.BackendName, timeout time.Duration) model.AllocationStatus {
+	allocation := existing
+	if allocation.ID == "" {
+		allocation.ID = newID()
+		allocation.CorrelationID = correlationIDFromContext(ctx)
+		allocation.Attempts = 0
+	}
+	allocation.Pool = pool
+	allocation.SelectedBackend = selected
+	allocation.Tenant = request.Tenant
+	allocation.PriorityClass = request.PriorityClass
+	allocation.RequestedLabels = append([]string(nil), request.Labels...)
+	allocation.Metadata = map[string]string{backend.MetadataLaunchModeKey: launchModeCold}
+	allocation.ExpiresAt = s.now().Add(timeout)
+	allocation.RetryAfter = time.Time{}
+	allocation.State = model.StateReserved
+	allocation.Error = ""
+	requestCopy := request
+	allocation.Request = &requestCopy
+	return allocation
+}
+
+func (s *Service) queueAllocation(ctx context.Context, request model.AllocationRequest, pool model.PoolName, selected model.BackendName, cause error, existing model.AllocationStatus) (model.AllocationStatus, bool) {
+	if !s.queueEnabled() || !queueableError(cause) {
+		return model.AllocationStatus{}, false
+	}
+	if existing.ID != "" && existing.Attempts >= normalizeQueueMaxAttempts(s.cfg.Broker.Queue) {
+		return model.AllocationStatus{}, false
+	}
+
+	now := s.now()
+	timeout := request.JobTimeout
+	if timeout <= 0 {
+		timeout = s.cfg.Broker.DefaultJobTimeout
+	}
+	if pool == "" {
+		pool = request.Pool
+	}
+	status := existing
+	if status.ID == "" {
+		status.ID = newID()
+		status.CorrelationID = correlationIDFromContext(ctx)
+		status.ExpiresAt = now.Add(timeout)
+	}
+	status.Pool = pool
+	status.SelectedBackend = selected
+	status.Tenant = request.Tenant
+	status.PriorityClass = request.PriorityClass
+	status.RequestedLabels = append([]string(nil), request.Labels...)
+	status.RetryAfter = now.Add(normalizeQueueRetryAfter(s.cfg.Broker.Queue))
+	status.State = model.StatePending
+	status.Error = cause.Error()
+	requestCopy := request
+	requestCopy.JobTimeout = timeout
+	status.Request = &requestCopy
+	if status.Metadata == nil {
+		status.Metadata = map[string]string{}
+	}
+	status.Metadata["queue_reason"] = queueReason(cause)
+	_ = s.store.Save(status)
+	logAllocationEvent(ctx, "allocation_pending", map[string]string{
+		"allocation_id": allocationIDLabel(status.ID),
+		"pool":          string(status.Pool),
+		"backend":       string(status.SelectedBackend),
+		"reason":        status.Metadata["queue_reason"],
+	})
+	return status, true
+}
+
+func (s *Service) ReconcileQueue(ctx context.Context, now time.Time) int {
+	if !s.queueEnabled() {
+		return 0
+	}
+	updated := 0
+	for _, status := range s.store.List() {
+		if status.State != model.StatePending {
+			continue
+		}
+		if !status.RetryAfter.IsZero() && status.RetryAfter.After(now) {
+			continue
+		}
+		if status.Request == nil {
+			s.store.MarkState(status.ID, model.StateFailed, now, "pending allocation is missing original request")
+			updated++
+			continue
+		}
+		if status.ExpiresAt.Before(now) {
+			s.store.MarkState(status.ID, model.StateExpired, now, "pending allocation expired")
+			updated++
+			continue
+		}
+		if status.Attempts >= normalizeQueueMaxAttempts(s.cfg.Broker.Queue) {
+			s.store.MarkState(status.ID, model.StateFailed, now, "pending allocation retry attempts exhausted")
+			updated++
+			continue
+		}
+		status.Attempts++
+		status.RetryAfter = now.Add(normalizeQueueRetryAfter(s.cfg.Broker.Queue))
+		_ = s.store.Save(status)
+		if _, err := s.allocateNow(ctx, *status.Request, status); err != nil {
+			if queued, ok := s.queueAllocation(ctx, *status.Request, status.Pool, status.SelectedBackend, err, status); ok {
+				_ = s.store.Save(queued)
+			} else {
+				s.store.MarkState(status.ID, model.StateFailed, now, err.Error())
+			}
+		}
+		updated++
+	}
+	s.observeState()
+	return updated
 }
 
 func (s *Service) ReconcileWarmPools() {
@@ -1174,6 +1369,10 @@ func isActiveAllocationState(state model.AllocationState) bool {
 	return state == model.StateReady || state == model.StateReserved
 }
 
+func isSchedulerAccountedState(state model.AllocationState) bool {
+	return state == model.StateReady || state == model.StateReserved || state == model.StateWarm
+}
+
 func isTerminalAllocationState(state model.AllocationState) bool {
 	switch state {
 	case model.StateCompleted, model.StateFailed, model.StateCanceled, model.StateExpired, model.StateQuarantined:
@@ -1220,6 +1419,59 @@ func defaultCompletionMessage(state model.AllocationState) string {
 	default:
 		return ""
 	}
+}
+
+func (s *Service) queueEnabled() bool {
+	return s.cfg.Broker.Queue.Enabled
+}
+
+func normalizeQueueRetryAfter(cfg model.AdmissionQueueConfig) time.Duration {
+	if cfg.RetryAfter > 0 {
+		return cfg.RetryAfter
+	}
+	return 30 * time.Second
+}
+
+func normalizeQueueMaxAttempts(cfg model.AdmissionQueueConfig) int {
+	if cfg.MaxAttempts > 0 {
+		return cfg.MaxAttempts
+	}
+	return 3
+}
+
+func queueableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, scheduler.ErrNoCapacity) || errors.Is(err, ErrBackendRateLimited) || errors.Is(err, ErrBackendCircuitOpen) {
+		return true
+	}
+	reason, ok := backend.FailureReason(err)
+	if !ok {
+		return false
+	}
+	switch reason {
+	case backend.FailureReasonTimeout, backend.FailureReasonTransport, backend.FailureReasonThrottled, backend.FailureReasonServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+func queueReason(err error) string {
+	if errors.Is(err, scheduler.ErrNoCapacity) {
+		return "no-capacity"
+	}
+	if errors.Is(err, ErrBackendRateLimited) {
+		return "rate-limited"
+	}
+	if errors.Is(err, ErrBackendCircuitOpen) {
+		return "circuit-open"
+	}
+	if reason, ok := backend.FailureReason(err); ok {
+		return reason
+	}
+	return "retryable"
 }
 
 func completionEventName(state model.AllocationState) string {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -102,6 +102,22 @@ func (b *countingBackend) Provision(_ context.Context, _ model.AllocationRequest
 	}, nil
 }
 
+type sequenceBackend struct {
+	testBackend
+	errs []error
+}
+
+func (b *sequenceBackend) Provision(ctx context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	if len(b.errs) > 0 {
+		err := b.errs[0]
+		b.errs = b.errs[1:]
+		if err != nil {
+			return backend.ProvisionedRunner{}, err
+		}
+	}
+	return b.testBackend.Provision(ctx, request, allocation)
+}
+
 func newServiceWithCountingBackend(mutator func(*model.PoolConfig), counting *countingBackend) *Service {
 	cfg := config.Default()
 	for index := range cfg.Pools {
@@ -180,6 +196,125 @@ func newServiceWithBrokerConfig(mutator func(*model.BrokerConfig)) *Service {
 		),
 		nil,
 	)
+}
+
+func TestFileStoreRehydratesSchedulerCapacity(t *testing.T) {
+	statePath := t.TempDir() + "/allocations.json"
+	cfg := config.Default()
+	cfg.Broker.StateStore = model.StateStoreConfig{Type: "file", Path: statePath}
+	cfg.Pools[0].Backends[model.BackendARC] = model.BackendConfig{
+		Enabled:    true,
+		Healthy:    true,
+		MaxRunners: 1,
+		Template:   "arc-full",
+	}
+
+	first := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}), nil)
+	if err := first.Health(context.Background()); err != nil {
+		t.Fatalf("first service health: %v", err)
+	}
+	allocation, err := first.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if allocation.State != model.StateReady {
+		t.Fatalf("expected ready allocation, got %s", allocation.State)
+	}
+
+	restarted := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}), nil)
+	if err := restarted.Health(context.Background()); err != nil {
+		t.Fatalf("restarted service health: %v", err)
+	}
+	if _, err := restarted.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute}); !errors.Is(err, scheduler.ErrNoCapacity) {
+		t.Fatalf("expected persisted active allocation to consume capacity, got %v", err)
+	}
+}
+
+func TestQueuePendingAllocationRetriesAfterCapacityIsReleased(t *testing.T) {
+	now := time.Unix(2000, 0)
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.Queue.Enabled = true
+		cfg.Broker.Queue.RetryAfter = time.Second
+		cfg.Broker.Queue.MaxAttempts = 2
+		cfg.Pools[0].Backends[model.BackendARC] = model.BackendConfig{
+			Enabled:    true,
+			Healthy:    true,
+			MaxRunners: 1,
+			Template:   "arc-full",
+		}
+	})
+	service.now = func() time.Time { return now }
+
+	first, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
+	if err != nil {
+		t.Fatalf("first allocate: %v", err)
+	}
+	pending, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
+	if err != nil {
+		t.Fatalf("expected second allocation to queue, got %v", err)
+	}
+	if pending.State != model.StatePending {
+		t.Fatalf("expected pending state, got %s", pending.State)
+	}
+
+	service.Cancel(first.ID)
+	now = now.Add(2 * time.Second)
+	if updated := service.ReconcileQueue(context.Background(), now); updated != 1 {
+		t.Fatalf("expected one queued allocation to reconcile, got %d", updated)
+	}
+	retried, ok := service.Get(pending.ID)
+	if !ok {
+		t.Fatal("expected queued allocation to still exist")
+	}
+	if retried.State != model.StateReady {
+		t.Fatalf("expected queued allocation to become ready, got %+v", retried)
+	}
+	if retried.Attempts != 1 {
+		t.Fatalf("expected one retry attempt, got %d", retried.Attempts)
+	}
+}
+
+func TestQueueRetriesTransientBackendFailure(t *testing.T) {
+	now := time.Unix(3000, 0)
+	cfg := config.Default()
+	cfg.Broker.Queue.Enabled = true
+	cfg.Broker.Queue.RetryAfter = time.Second
+	cfg.Broker.Queue.MaxAttempts = 2
+	cfg.Pools[0].Backends[model.BackendARC] = model.BackendConfig{
+		Enabled:    true,
+		Healthy:    true,
+		MaxRunners: 1,
+		Template:   "arc-full",
+	}
+	backendImpl := &sequenceBackend{
+		testBackend: testBackend{name: model.BackendARC},
+		errs:        []error{backend.NewClassifiedError(backend.FailureReasonTransport, errors.New("temporary transport failure"))},
+	}
+	service := NewService(cfg, backend.NewRegistry(backendImpl), nil)
+	service.now = func() time.Time { return now }
+
+	pending, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
+	if err != nil {
+		t.Fatalf("expected transient failure to queue, got %v", err)
+	}
+	if pending.State != model.StatePending {
+		t.Fatalf("expected pending allocation, got %+v", pending)
+	}
+
+	now = now.Add(2 * time.Second)
+	if updated := service.ReconcileQueue(context.Background(), now); updated != 1 {
+		t.Fatalf("expected one queue retry, got %d", updated)
+	}
+	retried, ok := service.Get(pending.ID)
+	if !ok {
+		t.Fatal("expected allocation to remain addressable")
+	}
+	if retried.State != model.StateReady {
+		t.Fatalf("expected retry to become ready, got %+v", retried)
+	}
+	if retried.RunnerLabel == "" {
+		t.Fatalf("expected ready allocation to include runner label: %+v", retried)
+	}
 }
 
 func TestAllocateUsesWeightedSchedulerForPool(t *testing.T) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -34,6 +34,14 @@ func Default() model.BrokerConfig {
 			API: model.BrokerAPIConfig{
 				OIDCAudience: "uecb-broker",
 			},
+			StateStore: model.StateStoreConfig{
+				Type: "memory",
+			},
+			Queue: model.AdmissionQueueConfig{
+				Enabled:     false,
+				RetryAfter:  30 * time.Second,
+				MaxAttempts: 3,
+			},
 			TierRouting: model.TierRoutingConfig{
 				Enabled:         false,
 				RefreshInterval: 5 * time.Minute,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -20,8 +20,38 @@ const (
 )
 
 func Validate(cfg model.BrokerConfig) error {
+	if err := validateStateStore(cfg.Broker.StateStore); err != nil {
+		return err
+	}
+	if err := validateAdmissionQueue(cfg.Broker.Queue); err != nil {
+		return err
+	}
 	if err := validateTierRouting(cfg); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateStateStore(cfg model.StateStoreConfig) error {
+	switch normalizeStringDefault(cfg.Type, "memory") {
+	case "memory":
+		return nil
+	case "file":
+		if strings.TrimSpace(cfg.Path) == "" {
+			return fmt.Errorf("broker.stateStore.path is required when type is file")
+		}
+		return nil
+	default:
+		return fmt.Errorf("broker.stateStore.type %q is not supported", cfg.Type)
+	}
+}
+
+func validateAdmissionQueue(cfg model.AdmissionQueueConfig) error {
+	if cfg.RetryAfter < 0 {
+		return fmt.Errorf("broker.queue.retryAfter must not be negative")
+	}
+	if cfg.MaxAttempts < 0 {
+		return fmt.Errorf("broker.queue.maxAttempts must not be negative")
 	}
 	return nil
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -35,6 +35,7 @@ const (
 	StateReserved    AllocationState = "reserved"
 	StateReady       AllocationState = "ready"
 	StateWarm        AllocationState = "warm"
+	StatePending     AllocationState = "pending"
 	StateCanceled    AllocationState = "canceled"
 	StateExpired     AllocationState = "expired"
 	StateFailed      AllocationState = "failed"
@@ -71,6 +72,17 @@ type BrokerAPIConfig struct {
 	OIDCAudience string `yaml:"oidcAudience" json:"oidcAudience"`
 }
 
+type StateStoreConfig struct {
+	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
+}
+
+type AdmissionQueueConfig struct {
+	Enabled     bool          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	RetryAfter  time.Duration `yaml:"retryAfter,omitempty" json:"retryAfter,omitempty"`
+	MaxAttempts int           `yaml:"maxAttempts,omitempty" json:"maxAttempts,omitempty"`
+}
+
 type BrokerRuntimeConfig struct {
 	DefaultPool          PoolName      `yaml:"defaultPool" json:"defaultPool"`
 	DefaultJobTimeout    time.Duration `yaml:"defaultJobTimeout" json:"defaultJobTimeout"`
@@ -79,8 +91,10 @@ type BrokerRuntimeConfig struct {
 		Enabled       bool          `yaml:"enabled" json:"enabled"`
 		QuarantineTTL time.Duration `yaml:"quarantineTTL" json:"quarantineTTL"`
 	} `yaml:"orphanCleanup" json:"orphanCleanup"`
-	API         BrokerAPIConfig   `yaml:"api" json:"api"`
-	TierRouting TierRoutingConfig `yaml:"tierRouting,omitempty" json:"tierRouting,omitempty"`
+	API         BrokerAPIConfig      `yaml:"api" json:"api"`
+	StateStore  StateStoreConfig     `yaml:"stateStore,omitempty" json:"stateStore,omitempty"`
+	Queue       AdmissionQueueConfig `yaml:"queue,omitempty" json:"queue,omitempty"`
+	TierRouting TierRoutingConfig    `yaml:"tierRouting,omitempty" json:"tierRouting,omitempty"`
 }
 
 type TierRoutingConfig struct {
@@ -200,16 +214,19 @@ type AllocationRequest struct {
 }
 
 type AllocationStatus struct {
-	ID              string            `json:"allocation_id"`
-	CorrelationID   string            `json:"correlation_id,omitempty"`
-	Pool            PoolName          `json:"pool"`
-	SelectedBackend BackendName       `json:"selected_backend"`
-	RunnerLabel     string            `json:"runner_label"`
-	RequestedLabels []string          `json:"requested_labels,omitempty"`
-	Tenant          string            `json:"tenant,omitempty"`
-	PriorityClass   string            `json:"priority_class,omitempty"`
-	ExpiresAt       time.Time         `json:"expires_at"`
-	State           AllocationState   `json:"state"`
-	Error           string            `json:"error,omitempty"`
-	Metadata        map[string]string `json:"metadata,omitempty"`
+	ID              string             `json:"allocation_id"`
+	CorrelationID   string             `json:"correlation_id,omitempty"`
+	Pool            PoolName           `json:"pool"`
+	SelectedBackend BackendName        `json:"selected_backend"`
+	RunnerLabel     string             `json:"runner_label"`
+	RequestedLabels []string           `json:"requested_labels,omitempty"`
+	Tenant          string             `json:"tenant,omitempty"`
+	PriorityClass   string             `json:"priority_class,omitempty"`
+	ExpiresAt       time.Time          `json:"expires_at"`
+	RetryAfter      time.Time          `json:"retry_after,omitempty"`
+	Attempts        int                `json:"attempts,omitempty"`
+	State           AllocationState    `json:"state"`
+	Error           string             `json:"error,omitempty"`
+	Metadata        map[string]string  `json:"metadata,omitempty"`
+	Request         *AllocationRequest `json:"request,omitempty"`
 }

--- a/internal/store/file.go
+++ b/internal/store/file.go
@@ -1,0 +1,141 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+const (
+	TypeMemory = "memory"
+	TypeFile   = "file"
+)
+
+type File struct {
+	mu          sync.RWMutex
+	path        string
+	allocations map[string]model.AllocationStatus
+}
+
+type fileSnapshot struct {
+	Allocations map[string]model.AllocationStatus `json:"allocations"`
+}
+
+func NewFromConfig(cfg model.StateStoreConfig) (Store, error) {
+	switch cfg.Type {
+	case "", TypeMemory:
+		return NewMemory(), nil
+	case TypeFile:
+		return NewFile(cfg.Path)
+	default:
+		return nil, fmt.Errorf("unsupported broker.stateStore.type %q", cfg.Type)
+	}
+}
+
+func NewFile(path string) (*File, error) {
+	if path == "" {
+		return nil, fmt.Errorf("broker.stateStore.path is required when type is file")
+	}
+	store := &File{
+		path:        path,
+		allocations: map[string]model.AllocationStatus{},
+	}
+	if err := store.load(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (f *File) Save(status model.AllocationStatus) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.allocations[status.ID] = status
+	return f.persistLocked()
+}
+
+func (f *File) Get(id string) (model.AllocationStatus, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	status, ok := f.allocations[id]
+	return status, ok
+}
+
+func (f *File) List() []model.AllocationStatus {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	result := make([]model.AllocationStatus, 0, len(f.allocations))
+	for _, status := range f.allocations {
+		result = append(result, status)
+	}
+	return result
+}
+
+func (f *File) MarkState(id string, state model.AllocationState, now time.Time, message string) (model.AllocationStatus, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	status, ok := f.allocations[id]
+	if !ok {
+		return model.AllocationStatus{}, false
+	}
+
+	status.State = state
+	if message != "" {
+		status.Error = message
+	}
+	if state == model.StateExpired || state == model.StateQuarantined {
+		status.ExpiresAt = now
+	}
+
+	f.allocations[id] = status
+	if err := f.persistLocked(); err != nil {
+		status.Error = err.Error()
+		f.allocations[id] = status
+	}
+	return status, true
+}
+
+func (f *File) load() error {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read state store %s: %w", f.path, err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var snapshot fileSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return fmt.Errorf("decode state store %s: %w", f.path, err)
+	}
+	if snapshot.Allocations != nil {
+		f.allocations = snapshot.Allocations
+	}
+	return nil
+}
+
+func (f *File) persistLocked() error {
+	if err := os.MkdirAll(filepath.Dir(f.path), 0o755); err != nil {
+		return fmt.Errorf("create state store directory: %w", err)
+	}
+	data, err := json.MarshalIndent(fileSnapshot{Allocations: f.allocations}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode state store: %w", err)
+	}
+	tmp := f.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write state store: %w", err)
+	}
+	if err := os.Rename(tmp, f.path); err != nil {
+		return fmt.Errorf("replace state store: %w", err)
+	}
+	return nil
+}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -7,6 +7,13 @@ import (
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
 
+type Store interface {
+	Save(model.AllocationStatus) error
+	Get(string) (model.AllocationStatus, bool)
+	List() []model.AllocationStatus
+	MarkState(string, model.AllocationState, time.Time, string) (model.AllocationStatus, bool)
+}
+
 type Memory struct {
 	mu          sync.RWMutex
 	allocations map[string]model.AllocationStatus
@@ -16,10 +23,11 @@ func NewMemory() *Memory {
 	return &Memory{allocations: map[string]model.AllocationStatus{}}
 }
 
-func (m *Memory) Save(status model.AllocationStatus) {
+func (m *Memory) Save(status model.AllocationStatus) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.allocations[status.ID] = status
+	return nil
 }
 
 func (m *Memory) Get(id string) (model.AllocationStatus, bool) {

--- a/pkg/adapter/adaptertest/conformance.go
+++ b/pkg/adapter/adaptertest/conformance.go
@@ -1,0 +1,87 @@
+package adaptertest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/pkg/adapter"
+)
+
+type Factory func(t testing.TB) adapter.Adapter
+
+type Options struct {
+	JobTimeout time.Duration
+}
+
+func RunConformance(t *testing.T, factory Factory, options Options) {
+	t.Helper()
+	if options.JobTimeout <= 0 {
+		options.JobTimeout = 15 * time.Minute
+	}
+
+	t.Run("health", func(t *testing.T) {
+		got, err := factory(t).Health(context.Background())
+		if err != nil {
+			t.Fatalf("Health returned error: %v", err)
+		}
+		if !got.Healthy {
+			t.Fatalf("Health returned unhealthy status: %+v", got)
+		}
+	})
+
+	t.Run("capacity", func(t *testing.T) {
+		got, err := factory(t).Capacity(context.Background())
+		if err != nil {
+			t.Fatalf("Capacity returned error: %v", err)
+		}
+		if got.MaxRunners <= 0 {
+			t.Fatalf("Capacity MaxRunners must be positive, got %+v", got)
+		}
+		if got.ActiveRunners < 0 || got.PendingRunners < 0 || got.WarmRunners < 0 {
+			t.Fatalf("Capacity counters must not be negative, got %+v", got)
+		}
+	})
+
+	t.Run("reserve-launch-cleanup", func(t *testing.T) {
+		adapterUnderTest := factory(t)
+		reservation, err := adapterUnderTest.Reserve(context.Background(), adapter.ReservationRequest{
+			AllocationID: "conformance-1",
+			Pool:         "lite",
+			Backend:      "mock",
+			Tenant:       "conformance",
+			Labels:       []string{"self-hosted", "linux", "x64"},
+			Capabilities: []string{"docker"},
+			JobTimeout:   options.JobTimeout,
+		})
+		if err != nil {
+			t.Fatalf("Reserve returned error: %v", err)
+		}
+		if strings.TrimSpace(reservation.AllocationID) == "" {
+			t.Fatalf("Reserve must preserve or generate an allocation id: %+v", reservation)
+		}
+		if strings.TrimSpace(reservation.RunnerLabel) == "" {
+			t.Fatalf("Reserve must return a runner label: %+v", reservation)
+		}
+		if !reservation.ExpiresAt.IsZero() && time.Until(reservation.ExpiresAt) <= 0 {
+			t.Fatalf("Reserve returned an already-expired reservation: %+v", reservation)
+		}
+
+		launch, err := adapterUnderTest.Launch(context.Background(), adapter.LaunchRequest{Reservation: reservation})
+		if err != nil {
+			t.Fatalf("Launch returned error: %v", err)
+		}
+		if strings.TrimSpace(launch.RunnerLabel) == "" {
+			t.Fatalf("Launch must return a runner label: %+v", launch)
+		}
+
+		if err := adapterUnderTest.Cleanup(context.Background(), adapter.CleanupRequest{
+			Reservation: reservation,
+			State:       adapter.StateCompleted,
+			Reason:      "conformance complete",
+		}); err != nil {
+			t.Fatalf("Cleanup returned error: %v", err)
+		}
+	})
+}

--- a/pkg/adapter/types.go
+++ b/pkg/adapter/types.go
@@ -1,0 +1,82 @@
+package adapter
+
+import (
+	"context"
+	"time"
+)
+
+type BackendName string
+type PoolName string
+
+type AllocationState string
+
+const (
+	StateReserved  AllocationState = "reserved"
+	StateReady     AllocationState = "ready"
+	StatePending   AllocationState = "pending"
+	StateCanceled  AllocationState = "canceled"
+	StateExpired   AllocationState = "expired"
+	StateFailed    AllocationState = "failed"
+	StateCompleted AllocationState = "completed"
+)
+
+type HealthStatus struct {
+	Healthy bool
+	Reason  string
+	Checked time.Time
+}
+
+type CapacityStatus struct {
+	MaxRunners     int
+	ActiveRunners  int
+	PendingRunners int
+	WarmRunners    int
+}
+
+type ReservationRequest struct {
+	AllocationID string
+	Pool         PoolName
+	Backend      BackendName
+	Tenant       string
+	Priority     string
+	Labels       []string
+	Capabilities []string
+	JobTimeout   time.Duration
+	Metadata     map[string]string
+}
+
+type Reservation struct {
+	AllocationID string
+	RunnerName   string
+	RunnerLabel  string
+	ExpiresAt    time.Time
+	Metadata     map[string]string
+}
+
+type LaunchRequest struct {
+	Reservation Reservation
+	Warm        bool
+	Metadata    map[string]string
+}
+
+type LaunchResult struct {
+	RunnerLabel string
+	StatusURL   string
+	DetailsURL  string
+	Metadata    map[string]string
+}
+
+type CleanupRequest struct {
+	Reservation Reservation
+	State       AllocationState
+	Reason      string
+	Metadata    map[string]string
+}
+
+type Adapter interface {
+	Health(context.Context) (HealthStatus, error)
+	Capacity(context.Context) (CapacityStatus, error)
+	Reserve(context.Context, ReservationRequest) (Reservation, error)
+	Launch(context.Context, LaunchRequest) (LaunchResult, error)
+	Cleanup(context.Context, CleanupRequest) error
+}


### PR DESCRIPTION
## Summary

- add a public backend adapter SDK, conformance harness, and mock reference adapter
- add configurable durable allocation storage with file-backed restart recovery and scheduler rehydration
- add optional queued admission for retryable capacity/provider failures, plus action polling and regression CI jobs

Closes #7

## Validation

- `/mnt/c/Program Files/Go/bin/go.exe test ./...`
- `git diff --check`
- `helm template uecb charts/unified-ephemeral-runner-broker >/tmp/uecb-helm.yaml`
- `kubectl kustomize examples/gitops/kustomize/base >/tmp/uecb-kustomize.yaml`
- `./scripts/audit_public_repo.sh`
