### PR TITLE
Reject disabled pinned Lambda backend

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -149,8 +149,6 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 		return model.AllocationStatus{}, err
 	}
 	resultPool = pool.Name
-	var fallbackSyntheticBackendPin bool
-	request.Backend, fallbackSyntheticBackendPin = s.resolveRequestedBackend(pool, request.Backend)
 
 	explicitTimeout := request.JobTimeout > 0
 	timeout := request.JobTimeout
@@ -177,25 +175,13 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 			return model.AllocationStatus{}, err
 		}
 	}
-	admissionInputPool := pool
 	pool, err = s.filterBackendsByAdmission(pool, request)
 	if err != nil {
-		if !fallbackSyntheticBackendPin || !errors.Is(err, ErrBackendRateLimited) && !errors.Is(err, ErrBackendCircuitOpen) {
-			if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
-				result = "queued"
-				return queued, nil
-			}
-			return model.AllocationStatus{}, err
+		if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
+			result = "queued"
+			return queued, nil
 		}
-		request.Backend = nil
-		pool, err = s.filterBackendsByAdmission(admissionInputPool, request)
-		if err != nil {
-			if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
-				result = "queued"
-				return queued, nil
-			}
-			return model.AllocationStatus{}, err
-		}
+		return model.AllocationStatus{}, err
 	}
 	pool, err = s.filterBackendsByTierState(pool, request)
 	if err != nil {
@@ -208,22 +194,11 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 
 	selected, err := s.reserve(pool, request)
 	if err != nil {
-		if !fallbackSyntheticBackendPin || request.Backend == nil || !errors.Is(err, scheduler.ErrNoCapacity) {
-			if queued, ok := s.queueAllocation(ctx, request, pool.Name, "", err, existing); ok {
-				result = "queued"
-				return queued, nil
-			}
-			return model.AllocationStatus{}, err
+		if queued, ok := s.queueAllocation(ctx, request, pool.Name, "", err, existing); ok {
+			result = "queued"
+			return queued, nil
 		}
-		request.Backend = nil
-		selected, err = s.reserve(pool, request)
-		if err != nil {
-			if queued, ok := s.queueAllocation(ctx, request, pool.Name, "", err, existing); ok {
-				result = "queued"
-				return queued, nil
-			}
-			return model.AllocationStatus{}, err
-		}
+		return model.AllocationStatus{}, err
 	}
 	if s.admission != nil {
 		decision := s.admission.allow(pool.Name, selected, pool.Backends[selected], s.now(), false, true)
@@ -1293,23 +1268,6 @@ func (s *Service) resolvePool(name model.PoolName) (model.PoolConfig, error) {
 		}
 	}
 	return model.PoolConfig{}, ErrUnknownPool
-}
-
-func (s *Service) resolveRequestedBackend(pool model.PoolConfig, requested *model.BackendName) (*model.BackendName, bool) {
-	if requested == nil {
-		return nil, false
-	}
-	if *requested != model.BackendLambda {
-		return requested, false
-	}
-
-	lambdaCfg, hasLambda := pool.Backends[model.BackendLambda]
-	codebuildCfg, hasCodebuild := pool.Backends[model.BackendCodeBuild]
-	if (!hasLambda || !lambdaCfg.Enabled) && hasCodebuild && codebuildCfg.Enabled {
-		backend := model.BackendCodeBuild
-		return &backend, true
-	}
-	return requested, false
 }
 
 func (s *Service) schedulerForPool(pool model.PoolConfig) scheduler.Scheduler {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -802,61 +802,6 @@ func TestRateLimitAppliesToSelectedColdBackendOnly(t *testing.T) {
 	}
 }
 
-func TestDisabledLambdaFallbackSkipsRateLimitedCodeBuild(t *testing.T) {
-	service := newServiceWithConfig(func(pool *model.PoolConfig) {
-		if pool.Name != model.PoolLite {
-			return
-		}
-		for name, backendCfg := range pool.Backends {
-			backendCfg.Enabled = false
-			pool.Backends[name] = backendCfg
-		}
-		arcCfg := pool.Backends[model.BackendARC]
-		arcCfg.Enabled = true
-		arcCfg.Healthy = true
-		arcCfg.MaxRunners = 1
-		pool.Backends[model.BackendARC] = arcCfg
-
-		codebuildCfg := pool.Backends[model.BackendCodeBuild]
-		codebuildCfg.Enabled = true
-		codebuildCfg.Healthy = true
-		codebuildCfg.MaxRunners = 1
-		codebuildCfg.RateLimit.Enabled = true
-		codebuildCfg.RateLimit.Permits = 1
-		codebuildCfg.RateLimit.Interval = time.Hour
-		pool.Backends[model.BackendCodeBuild] = codebuildCfg
-	})
-	service.now = func() time.Time { return time.Unix(1000, 0) }
-
-	pinnedLambda := model.BackendLambda
-	first, err := service.Allocate(context.Background(), model.AllocationRequest{
-		Pool:       model.PoolLite,
-		Backend:    &pinnedLambda,
-		JobTimeout: 5 * time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("first lambda fallback allocation failed: %v", err)
-	}
-	if first.SelectedBackend != model.BackendCodeBuild {
-		t.Fatalf("expected disabled lambda to prefer codebuild, got %s", first.SelectedBackend)
-	}
-	if _, ok := service.Cancel(first.ID); !ok {
-		t.Fatal("cancel failed")
-	}
-
-	second, err := service.Allocate(context.Background(), model.AllocationRequest{
-		Pool:       model.PoolLite,
-		Backend:    &pinnedLambda,
-		JobTimeout: 5 * time.Minute,
-	})
-	if err != nil {
-		t.Fatalf("expected rate-limited codebuild fallback allocation to succeed: %v", err)
-	}
-	if second.SelectedBackend != model.BackendARC {
-		t.Fatalf("expected arc fallback after codebuild rate limit, got %s", second.SelectedBackend)
-	}
-}
-
 func TestHalfOpenAdmissionDoesNotConsumeProbeSlotDuringFiltering(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {
@@ -982,20 +927,17 @@ func TestProbeRecoveryRequiresConsecutiveSuccesses(t *testing.T) {
 	}
 }
 
-func TestAllocateTreatsLegacyPinnedLambdaAsCodeBuildWhenLambdaBackendIsDisabled(t *testing.T) {
+func TestAllocateRejectsPinnedLambdaWhenLambdaBackendIsDisabled(t *testing.T) {
 	service := newService()
 	backend := model.BackendLambda
 
-	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{
 		Pool:       model.PoolLite,
 		Backend:    &backend,
 		JobTimeout: 5 * time.Minute,
 	})
-	if err != nil {
-		t.Fatalf("expected legacy lambda pin to fall back to codebuild: %v", err)
-	}
-	if allocation.SelectedBackend != model.BackendCodeBuild {
-		t.Fatalf("expected legacy lambda pin to select codebuild, got %s", allocation.SelectedBackend)
+	if !errors.Is(err, scheduler.ErrNoCapacity) {
+		t.Fatalf("expected disabled pinned lambda to fail capacity check, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep explicit Lambda backend pins explicit instead of silently rewriting them to CodeBuild
- reject disabled Lambda pins with the normal capacity error
- update API regression coverage for disabled and enabled Lambda pins

## Validation
- go test ./...
