### PR TITLE
Add provider spend routing and resilient rehydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ broker:
         provider: aws
         mode: free-tier
         secretRef: uecb-aws-billing
+    providerRules:
+      - name: aws-free-tier
+        providerRef: aws-main
+        hardLimitRatio: 0.95
+        action: disable
 pools:
   - name: lite
     backends:
@@ -326,13 +331,15 @@ pools:
             action: observe-only
 ```
 
+`providerRules` apply one provider budget, free-tier, or credit decision to every matching backend in every pool. The broker maps `aws` to CodeBuild, Lambda, and EC2; `gcp` to Cloud Run and GCE; and `azure` to Azure Functions and Azure VM. Use `backends` on a provider rule when only a subset should be affected.
+
 Supported fallback modes:
 
 - `pass-through-round-robin`: default; unknown or stale tier data does not block builds.
 - `block`: fail allocations when tier data is unknown, stale, or over policy.
 - `fallback-backends`: route to configured fallback backends such as `arc`.
 
-Use `observe-only` first, then move a backend rule to `deprioritize` or `disable` after validating Prometheus queries and provider snapshots. Pinned requests fail clearly when the requested backend is tier-blocked.
+Use `observe-only` first, then move a provider or backend rule to `deprioritize` or `disable` after validating Prometheus queries and provider snapshots. Pinned requests fail clearly when the requested backend is tier-blocked.
 
 ## Runtime Backend Admission
 

--- a/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
+++ b/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
@@ -30,5 +30,7 @@ data:
       allowUnauthenticated: {{ .Values.config.allowUnauthenticated }}
       api:
         oidcAudience: {{ .Values.config.broker.api.oidcAudience }}
+      tierRouting:
+{{ toYaml .Values.config.broker.tierRouting | indent 8 }}
     pools:
 {{ toYaml .Values.config.pools | indent 6 }}

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -67,6 +67,7 @@ config:
       enabled: false
       refreshInterval: 5m
       staleAfter: 15m
+      refreshOnStartup: true
       failureMode: pass-through-round-robin
       fallbackBackends:
         - arc
@@ -75,6 +76,7 @@ config:
         timeout: 2s
         secretRef: ""
       providers: {}
+      providerRules: []
   pools:
     - name: full
       labels:
@@ -83,7 +85,7 @@ config:
         - x64
         - uecb
         - uecb-full
-      # Backend schedulers: round-robin, weighted-round-robin
+      # Backend schedulers: round-robin, weighted-round-robin, priority-fair-share
       scheduler: round-robin
       fairShare:
         enabled: false
@@ -109,7 +111,7 @@ config:
         - x64
         - uecb
         - uecb-lite
-      # Backend schedulers: round-robin, weighted-round-robin
+      # Backend schedulers: round-robin, weighted-round-robin, priority-fair-share
       scheduler: round-robin
       fairShare:
         enabled: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,8 @@ Tier-aware routing is evaluated after static eligibility, capability filtering, 
 
 The allocation path only reads cached tier decisions. Prometheus queries and provider budget, free-tier, or credit calls are refreshed out of band and stored in memory per broker process. This keeps allocation latency independent from billing API latency and avoids making `/healthz` depend on cloud billing availability.
 
+Provider-level `broker.tierRouting.providerRules` are evaluated once per provider snapshot and then applied to every matching backend in each pool. This makes spend limits a first-class routing input: if the AWS provider decision is exceeded with `action: disable`, CodeBuild, Lambda, and EC2 are removed before the scheduler sees the candidate pool.
+
 Tier states are normalized to `healthy`, `approaching`, `exceeded`, and `unknown`. Rule actions are `observe-only`, `deprioritize`, and `disable`. `observe-only` never changes routing. `disable` removes an approaching or exceeded backend from scheduler eligibility. Unknown or stale data follows `broker.tierRouting.failureMode`:
 
 - `pass-through-round-robin`: default; ignore tier data and preserve build throughput.
@@ -86,6 +88,8 @@ Tier states are normalized to `healthy`, `approaching`, `exceeded`, and `unknown
 - `fallback-backends`: route through explicit fallback backends, usually `arc` or another self-hosted label.
 
 Pinned backend requests are not silently rerouted when tier policy blocks the pinned backend. The broker returns a deterministic tier-policy error instead.
+
+Persisted allocation state is rehydrated best-effort on startup. Active, unexpired allocations that still fit the current pool/backend config count against scheduler capacity. Terminal, expired, or no-longer-rehydratable allocations are left visible in the state store but marked terminal so stale state cannot make `/healthz` fail after a backend is disabled.
 
 ## Capability Filtering
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -97,17 +97,24 @@ func (s *Service) rehydrateSchedulerState() error {
 	if s.store == nil {
 		return nil
 	}
+	now := s.now()
 	for _, status := range s.store.List() {
 		if !isSchedulerAccountedState(status.State) {
 			continue
 		}
 		pool, err := s.resolvePool(status.Pool)
 		if err != nil {
-			return fmt.Errorf("rehydrate allocation %s: %w", status.ID, err)
+			s.expireUnrehydratableAllocation(status, now, fmt.Sprintf("rehydrate skipped: %v", err))
+			continue
 		}
 		selected := status.SelectedBackend
 		if selected == "" {
-			return fmt.Errorf("rehydrate allocation %s: selected backend is empty", status.ID)
+			s.expireUnrehydratableAllocation(status, now, "rehydrate skipped: selected backend is empty")
+			continue
+		}
+		if !status.ExpiresAt.IsZero() && !status.ExpiresAt.After(now) {
+			s.expireUnrehydratableAllocation(status, now, "rehydrate skipped: allocation expired")
+			continue
 		}
 		request := model.AllocationRequest{
 			Pool:          status.Pool,
@@ -116,10 +123,29 @@ func (s *Service) rehydrateSchedulerState() error {
 			PriorityClass: status.PriorityClass,
 		}
 		if _, err := s.reserve(pool, request); err != nil {
-			return fmt.Errorf("rehydrate allocation %s on backend %s: %w", status.ID, selected, err)
+			s.expireUnrehydratableAllocation(status, now, fmt.Sprintf("rehydrate skipped: %v", err))
+			continue
 		}
 	}
 	return nil
+}
+
+func (s *Service) expireUnrehydratableAllocation(status model.AllocationStatus, now time.Time, reason string) {
+	if status.ID == "" || s.store == nil {
+		return
+	}
+	nextState := model.StateExpired
+	if status.State == model.StateWarm {
+		nextState = model.StateFailed
+	}
+	_, _ = s.store.MarkState(status.ID, nextState, now, reason)
+	logAllocationEvent(context.Background(), "allocation_rehydrate_skipped", map[string]string{
+		"allocation_id": allocationIDLabel(status.ID),
+		"pool":          string(status.Pool),
+		"backend":       string(status.SelectedBackend),
+		"state":         string(status.State),
+		"reason":        reason,
+	})
 }
 
 func (s *Service) Allocate(ctx context.Context, request model.AllocationRequest) (model.AllocationStatus, error) {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -230,6 +230,67 @@ func TestFileStoreRehydratesSchedulerCapacity(t *testing.T) {
 	}
 }
 
+func TestFileStoreRehydrateExpiresUnrehydratableAllocation(t *testing.T) {
+	statePath := t.TempDir() + "/allocations.json"
+	cfg := config.Default()
+	cfg.Broker.StateStore = model.StateStoreConfig{Type: "file", Path: statePath}
+
+	writer := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}, testBackend{name: model.BackendCodeBuild}), nil)
+	if err := writer.store.Save(model.AllocationStatus{
+		ID:              "stale-codebuild",
+		Pool:            model.PoolLite,
+		SelectedBackend: model.BackendCodeBuild,
+		ExpiresAt:       time.Now().Add(30 * time.Minute),
+		State:           model.StateReady,
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	restarted := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}, testBackend{name: model.BackendCodeBuild}), nil)
+	if err := restarted.Health(context.Background()); err != nil {
+		t.Fatalf("restarted service health should ignore unrehydratable state: %v", err)
+	}
+	status, ok := restarted.Get("stale-codebuild")
+	if !ok {
+		t.Fatal("expected stale allocation to remain visible")
+	}
+	if status.State != model.StateExpired {
+		t.Fatalf("expected stale allocation to be expired, got %s", status.State)
+	}
+	if !strings.Contains(status.Error, "rehydrate skipped") {
+		t.Fatalf("expected rehydrate skip reason, got %q", status.Error)
+	}
+}
+
+func TestFileStoreRehydrateExpiresPastDeadlineAllocation(t *testing.T) {
+	statePath := t.TempDir() + "/allocations.json"
+	cfg := config.Default()
+	cfg.Broker.StateStore = model.StateStoreConfig{Type: "file", Path: statePath}
+
+	writer := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}), nil)
+	if err := writer.store.Save(model.AllocationStatus{
+		ID:              "expired-active",
+		Pool:            model.PoolFull,
+		SelectedBackend: model.BackendARC,
+		ExpiresAt:       time.Now().Add(-time.Minute),
+		State:           model.StateReady,
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	restarted := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}), nil)
+	if err := restarted.Health(context.Background()); err != nil {
+		t.Fatalf("restarted service health should ignore expired active state: %v", err)
+	}
+	status, ok := restarted.Get("expired-active")
+	if !ok {
+		t.Fatal("expected expired allocation to remain visible")
+	}
+	if status.State != model.StateExpired {
+		t.Fatalf("expected allocation to be expired, got %s", status.State)
+	}
+}
+
 func TestQueuePendingAllocationRetriesAfterCapacityIsReleased(t *testing.T) {
 	now := time.Unix(2000, 0)
 	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -43,10 +43,11 @@ func Default() model.BrokerConfig {
 				MaxAttempts: 3,
 			},
 			TierRouting: model.TierRoutingConfig{
-				Enabled:         false,
-				RefreshInterval: 5 * time.Minute,
-				StaleAfter:      15 * time.Minute,
-				FailureMode:     "pass-through-round-robin",
+				Enabled:          false,
+				RefreshInterval:  5 * time.Minute,
+				StaleAfter:       15 * time.Minute,
+				FailureMode:      "pass-through-round-robin",
+				RefreshOnStartup: true,
 				Prometheus: model.TierPrometheusConfig{
 					Timeout: 2 * time.Second,
 				},

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -103,6 +103,11 @@ broker:
         provider: aws
         mode: free-tier
         secretRef: uecb-aws-billing
+    providerRules:
+      - name: aws-free-tier
+        providerRef: aws-main
+        hardLimitRatio: 0.9
+        action: disable
 pools:
   - name: lite
     backends:
@@ -136,6 +141,10 @@ pools:
 	if provider.Provider != "aws" || provider.Mode != "free-tier" || provider.SecretRef != "uecb-aws-billing" {
 		t.Fatalf("unexpected provider config: %+v", provider)
 	}
+	providerRule := cfg.Broker.TierRouting.ProviderRules[0]
+	if providerRule.ProviderRef != "aws-main" || providerRule.Action != "disable" || providerRule.HardLimitRatio != 0.9 {
+		t.Fatalf("unexpected provider tier rule: %+v", providerRule)
+	}
 	rule := cfg.Pools[0].Backends[model.BackendCodeBuild].TierRules[0]
 	if rule.ProviderRef != "aws-main" || rule.Action != "disable" || rule.HardLimitRatio != 0.9 {
 		t.Fatalf("unexpected tier rule: %+v", rule)
@@ -156,6 +165,14 @@ pools:
       codebuild:
         tierRules:
           - providerRef: missing-provider
+`,
+		"invalid provider rule ref": `
+broker:
+  tierRouting:
+    enabled: true
+    providerRules:
+      - providerRef: missing-provider
+        hardLimitRatio: 0.9
 `,
 		"invalid threshold order": `
 broker:

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -104,6 +104,12 @@ func validateTierRouting(cfg model.BrokerConfig) error {
 		}
 	}
 
+	for index, rule := range tierCfg.ProviderRules {
+		if err := validateProviderTierRule(cfg, tierCfg, index, rule); err != nil {
+			return err
+		}
+	}
+
 	for _, pool := range cfg.Pools {
 		for backendName, backendCfg := range pool.Backends {
 			for index, rule := range backendCfg.TierRules {
@@ -114,6 +120,34 @@ func validateTierRouting(cfg model.BrokerConfig) error {
 		}
 	}
 	return nil
+}
+
+func validateProviderTierRule(cfg model.BrokerConfig, tierCfg model.TierRoutingConfig, index int, rule model.ProviderTierRuleConfig) error {
+	prefix := fmt.Sprintf("broker.tierRouting.providerRules[%d]", index)
+	if strings.TrimSpace(rule.ProviderRef) == "" {
+		return fmt.Errorf("%s.providerRef is required", prefix)
+	}
+	if _, ok := tierCfg.Providers[rule.ProviderRef]; !ok {
+		return fmt.Errorf("%s.providerRef %q does not match a configured provider", prefix, rule.ProviderRef)
+	}
+	if len(rule.Backends) > 0 {
+		for _, backendName := range rule.Backends {
+			if !backendNameConfigured(cfg, backendName) {
+				return fmt.Errorf("%s.backends includes unknown backend %q", prefix, backendName)
+			}
+		}
+	}
+	return validateTierRule(tierCfg, "", "", index, model.TierRuleConfig{
+		Name:               rule.Name,
+		ProviderRef:        rule.ProviderRef,
+		UsageQuery:         rule.UsageQuery,
+		BurnRateQuery:      rule.BurnRateQuery,
+		SoftLimitRatio:     rule.SoftLimitRatio,
+		HardLimitRatio:     rule.HardLimitRatio,
+		MinRemainingCredit: rule.MinRemainingCredit,
+		ProjectionWindow:   rule.ProjectionWindow,
+		Action:             rule.Action,
+	})
 }
 
 func validateTierRule(tierCfg model.TierRoutingConfig, pool model.PoolName, backend model.BackendName, index int, rule model.TierRuleConfig) error {
@@ -161,6 +195,9 @@ func validateTierRule(tierCfg model.TierRoutingConfig, pool model.PoolName, back
 }
 
 func hasTierRules(cfg model.BrokerConfig) bool {
+	if len(cfg.Broker.TierRouting.ProviderRules) > 0 {
+		return true
+	}
 	for _, pool := range cfg.Pools {
 		for _, backend := range pool.Backends {
 			if len(backend.TierRules) > 0 {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -105,6 +105,7 @@ type TierRoutingConfig struct {
 	FallbackBackends []BackendName                 `yaml:"fallbackBackends,omitempty" json:"fallbackBackends,omitempty"`
 	Prometheus       TierPrometheusConfig          `yaml:"prometheus,omitempty" json:"prometheus,omitempty"`
 	Providers        map[string]TierProviderConfig `yaml:"providers,omitempty" json:"providers,omitempty"`
+	ProviderRules    []ProviderTierRuleConfig      `yaml:"providerRules,omitempty" json:"providerRules,omitempty"`
 	RefreshOnStartup bool                          `yaml:"refreshOnStartup,omitempty" json:"refreshOnStartup,omitempty"`
 }
 
@@ -172,6 +173,19 @@ type TierRuleConfig struct {
 	BurnRateQuery      string        `yaml:"burnRateQuery,omitempty" json:"burnRateQuery,omitempty"`
 	LimitSources       []string      `yaml:"limitSources,omitempty" json:"limitSources,omitempty"`
 	Combine            string        `yaml:"combine,omitempty" json:"combine,omitempty"`
+	SoftLimitRatio     float64       `yaml:"softLimitRatio,omitempty" json:"softLimitRatio,omitempty"`
+	HardLimitRatio     float64       `yaml:"hardLimitRatio,omitempty" json:"hardLimitRatio,omitempty"`
+	MinRemainingCredit float64       `yaml:"minRemainingCredit,omitempty" json:"minRemainingCredit,omitempty"`
+	ProjectionWindow   time.Duration `yaml:"projectionWindow,omitempty" json:"projectionWindow,omitempty"`
+	Action             string        `yaml:"action,omitempty" json:"action,omitempty"`
+}
+
+type ProviderTierRuleConfig struct {
+	Name               string        `yaml:"name,omitempty" json:"name,omitempty"`
+	ProviderRef        string        `yaml:"providerRef,omitempty" json:"providerRef,omitempty"`
+	Backends           []BackendName `yaml:"backends,omitempty" json:"backends,omitempty"`
+	UsageQuery         string        `yaml:"usageQuery,omitempty" json:"usageQuery,omitempty"`
+	BurnRateQuery      string        `yaml:"burnRateQuery,omitempty" json:"burnRateQuery,omitempty"`
 	SoftLimitRatio     float64       `yaml:"softLimitRatio,omitempty" json:"softLimitRatio,omitempty"`
 	HardLimitRatio     float64       `yaml:"hardLimitRatio,omitempty" json:"hardLimitRatio,omitempty"`
 	MinRemainingCredit float64       `yaml:"minRemainingCredit,omitempty" json:"minRemainingCredit,omitempty"`

--- a/internal/tier/config_refresher.go
+++ b/internal/tier/config_refresher.go
@@ -3,6 +3,7 @@ package tier
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -36,8 +37,15 @@ func (r *ConfigRefresher) Refresh(ctx context.Context) ([]Decision, error) {
 		return nil, nil
 	}
 	now := r.now()
-	decisions := make([]Decision, 0)
+	decisions := map[decisionKey]Decision{}
 	var firstErr error
+	for _, ruleCfg := range r.cfg.Broker.TierRouting.ProviderRules {
+		decision, err := r.refreshProviderRule(ctx, ruleCfg, now)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		r.addProviderRuleDecisions(decisions, decision, ruleCfg)
+	}
 	for _, pool := range r.cfg.Pools {
 		for backendName, backendCfg := range pool.Backends {
 			for _, ruleCfg := range backendCfg.TierRules {
@@ -45,11 +53,11 @@ func (r *ConfigRefresher) Refresh(ctx context.Context) ([]Decision, error) {
 				if err != nil && firstErr == nil {
 					firstErr = err
 				}
-				decisions = append(decisions, decision)
+				mergeDecision(decisions, decision)
 			}
 		}
 	}
-	return decisions, firstErr
+	return sortedDecisions(decisions), firstErr
 }
 
 func (r *ConfigRefresher) refreshRule(ctx context.Context, pool model.PoolName, backendName model.BackendName, ruleCfg model.TierRuleConfig, now time.Time) (Decision, error) {
@@ -138,6 +146,38 @@ func (r *ConfigRefresher) refreshRule(ctx context.Context, pool model.PoolName, 
 		Now:       now,
 	})
 	return decision, firstErr
+}
+
+func (r *ConfigRefresher) refreshProviderRule(ctx context.Context, ruleCfg model.ProviderTierRuleConfig, now time.Time) (Decision, error) {
+	return r.refreshRule(ctx, "", "", model.TierRuleConfig{
+		Name:               ruleCfg.Name,
+		ProviderRef:        ruleCfg.ProviderRef,
+		UsageQuery:         ruleCfg.UsageQuery,
+		BurnRateQuery:      ruleCfg.BurnRateQuery,
+		SoftLimitRatio:     ruleCfg.SoftLimitRatio,
+		HardLimitRatio:     ruleCfg.HardLimitRatio,
+		MinRemainingCredit: ruleCfg.MinRemainingCredit,
+		ProjectionWindow:   ruleCfg.ProjectionWindow,
+		Action:             ruleCfg.Action,
+	}, now)
+}
+
+func (r *ConfigRefresher) addProviderRuleDecisions(decisions map[decisionKey]Decision, decision Decision, ruleCfg model.ProviderTierRuleConfig) {
+	providerCfg, ok := r.cfg.Broker.TierRouting.Providers[ruleCfg.ProviderRef]
+	if !ok {
+		return
+	}
+	for _, pool := range r.cfg.Pools {
+		for backendName, backendCfg := range pool.Backends {
+			if !providerRuleMatchesBackend(ruleCfg, providerCfg, backendName, backendCfg) {
+				continue
+			}
+			next := decision
+			next.Pool = pool.Name
+			next.Backend = backendName
+			mergeDecision(decisions, next)
+		}
+	}
 }
 
 func (r *ConfigRefresher) providerSnapshot(ctx context.Context, ref string, now time.Time) (SourceSnapshot, error) {
@@ -241,4 +281,100 @@ func resolvePrometheusTimeout(timeout time.Duration) time.Duration {
 		return timeout
 	}
 	return 2 * time.Second
+}
+
+type decisionKey struct {
+	pool    model.PoolName
+	backend model.BackendName
+}
+
+func mergeDecision(decisions map[decisionKey]Decision, next Decision) {
+	key := decisionKey{pool: next.Pool, backend: next.Backend}
+	current, ok := decisions[key]
+	if !ok || decisionMoreRestrictive(next, current) {
+		decisions[key] = next
+	}
+}
+
+func sortedDecisions(decisions map[decisionKey]Decision) []Decision {
+	result := make([]Decision, 0, len(decisions))
+	for _, decision := range decisions {
+		result = append(result, decision)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Pool != result[j].Pool {
+			return result[i].Pool < result[j].Pool
+		}
+		return result[i].Backend < result[j].Backend
+	})
+	return result
+}
+
+func decisionMoreRestrictive(candidate, current Decision) bool {
+	if decisionStateRank(candidate) != decisionStateRank(current) {
+		return decisionStateRank(candidate) > decisionStateRank(current)
+	}
+	return decisionActionRank(candidate.Action) > decisionActionRank(current.Action)
+}
+
+func decisionStateRank(decision Decision) int {
+	if decision.Stale {
+		return 2
+	}
+	switch decision.State {
+	case StateExceeded:
+		return 4
+	case StateApproaching:
+		return 3
+	case StateUnknown:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func decisionActionRank(action string) int {
+	switch normalizeAction(action) {
+	case ActionDisable:
+		return 3
+	case ActionDeprioritize:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func providerRuleMatchesBackend(ruleCfg model.ProviderTierRuleConfig, providerCfg model.TierProviderConfig, backendName model.BackendName, backendCfg model.BackendConfig) bool {
+	if len(ruleCfg.Backends) > 0 {
+		for _, candidate := range ruleCfg.Backends {
+			if candidate == backendName {
+				return true
+			}
+		}
+		return false
+	}
+	return backendProvider(backendName, backendCfg) == strings.ToLower(strings.TrimSpace(providerCfg.Provider))
+}
+
+func backendProvider(backendName model.BackendName, backendCfg model.BackendConfig) string {
+	for _, capability := range backendCfg.Capabilities {
+		switch strings.ToLower(strings.TrimSpace(capability)) {
+		case "cloud:aws":
+			return "aws"
+		case "cloud:azure":
+			return "azure"
+		case "cloud:gcp":
+			return "gcp"
+		}
+	}
+	switch backendName {
+	case model.BackendCodeBuild, model.BackendLambda, model.BackendEC2:
+		return "aws"
+	case model.BackendCloudRun, model.BackendGCE:
+		return "gcp"
+	case model.BackendAzureFunctions, model.BackendAzureVM:
+		return "azure"
+	default:
+		return ""
+	}
 }

--- a/internal/tier/config_refresher_test.go
+++ b/internal/tier/config_refresher_test.go
@@ -78,3 +78,133 @@ func TestConfigRefresherCombinesPrometheusUsageWithProviderLimit(t *testing.T) {
 		t.Fatalf("expected exceeded decision, got %+v", decisions[0])
 	}
 }
+
+func TestConfigRefresherAppliesProviderRuleToMatchingBackends(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"limit":100,"used":96,"updated_at":"` + now.Format(time.RFC3339) + `"}`))
+	}))
+	defer providerServer.Close()
+
+	refresher := NewConfigRefresher(model.BrokerConfig{
+		Broker: model.BrokerRuntimeConfig{
+			TierRouting: model.TierRoutingConfig{
+				Enabled: true,
+				Providers: map[string]model.TierProviderConfig{
+					"aws-main": {
+						Provider:  "aws",
+						Mode:      "budget",
+						SecretRef: "aws",
+					},
+				},
+				ProviderRules: []model.ProviderTierRuleConfig{{
+					Name:           "aws-budget",
+					ProviderRef:    "aws-main",
+					HardLimitRatio: 0.95,
+					Action:         ActionDisable,
+				}},
+			},
+		},
+		Pools: []model.PoolConfig{{
+			Name: model.PoolLite,
+			Backends: map[model.BackendName]model.BackendConfig{
+				model.BackendCodeBuild: {},
+				model.BackendEC2: {
+					Capabilities: []string{"cloud:aws"},
+				},
+				model.BackendAzureVM: {
+					Capabilities: []string{"cloud:azure"},
+				},
+				model.BackendGCE: {
+					Capabilities: []string{"cloud:gcp"},
+				},
+			},
+		}},
+	}, staticSecretReader{
+		"aws": {"snapshot_url": providerServer.URL},
+	})
+	refresher.now = func() time.Time { return now }
+
+	decisions, err := refresher.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh returned error: %v", err)
+	}
+	got := decisionsByBackend(decisions)
+	for _, backendName := range []model.BackendName{model.BackendCodeBuild, model.BackendEC2} {
+		decision, ok := got[backendName]
+		if !ok {
+			t.Fatalf("expected decision for %s", backendName)
+		}
+		if decision.State != StateExceeded || decision.Action != ActionDisable {
+			t.Fatalf("expected exceeded disable for %s, got %+v", backendName, decision)
+		}
+	}
+	for _, backendName := range []model.BackendName{model.BackendAzureVM, model.BackendGCE} {
+		if _, ok := got[backendName]; ok {
+			t.Fatalf("did not expect AWS provider rule to affect %s", backendName)
+		}
+	}
+}
+
+func TestConfigRefresherMergesProviderAndBackendRulesMostRestrictively(t *testing.T) {
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"limit":100,"used":96,"updated_at":"` + now.Format(time.RFC3339) + `"}`))
+	}))
+	defer providerServer.Close()
+
+	refresher := NewConfigRefresher(model.BrokerConfig{
+		Broker: model.BrokerRuntimeConfig{
+			TierRouting: model.TierRoutingConfig{
+				Enabled: true,
+				Providers: map[string]model.TierProviderConfig{
+					"aws-main": {
+						Provider:  "aws",
+						Mode:      "budget",
+						SecretRef: "aws",
+					},
+				},
+				ProviderRules: []model.ProviderTierRuleConfig{{
+					Name:           "aws-budget",
+					ProviderRef:    "aws-main",
+					HardLimitRatio: 0.95,
+					Action:         ActionDisable,
+				}},
+			},
+		},
+		Pools: []model.PoolConfig{{
+			Name: model.PoolLite,
+			Backends: map[model.BackendName]model.BackendConfig{
+				model.BackendCodeBuild: {
+					TierRules: []model.TierRuleConfig{{
+						Name:           "codebuild-observe",
+						ProviderRef:    "aws-main",
+						HardLimitRatio: 0.99,
+						Action:         ActionObserveOnly,
+					}},
+				},
+			},
+		}},
+	}, staticSecretReader{
+		"aws": {"snapshot_url": providerServer.URL},
+	})
+	refresher.now = func() time.Time { return now }
+
+	decisions, err := refresher.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh returned error: %v", err)
+	}
+	got := decisionsByBackend(decisions)
+	decision := got[model.BackendCodeBuild]
+	if decision.State != StateExceeded || decision.Action != ActionDisable {
+		t.Fatalf("expected provider disable decision to win, got %+v", decision)
+	}
+}
+
+func decisionsByBackend(decisions []Decision) map[model.BackendName]Decision {
+	result := map[model.BackendName]Decision{}
+	for _, decision := range decisions {
+		result[decision.Backend] = decision
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- add provider-level tier routing rules so a single AWS/GCP/Azure spend decision can disable or deprioritize all matching backends before scheduler selection
- merge provider-level and backend-level tier decisions by the most restrictive result
- make startup rehydration expire stale or unrehydratable active allocations instead of failing broker health
- render tierRouting through the Helm chart ConfigMap

No linked GitHub issue was provided; this PR comes from the live spend-balancing incident.

## Validation
- `"/mnt/c/Program Files/Go/bin/go.exe" test ./...`
- `helm template uecb charts/unified-ephemeral-runner-broker >/tmp/uecb-helm.yaml`
- `kubectl kustomize examples/gitops/kustomize/base >/tmp/uecb-kustomize.yaml`