### PR TITLE
Fail over rate-limited backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,9 @@ pools:
           recoverySuccessThreshold: 1
 ```
 
-`rateLimit` applies only to cold provisioning attempts. Warm runner reuse is not rate limited.
+`rateLimit` applies only to cold provisioning attempts. Warm runner reuse is not rate limited. When a cold
+backend is rate-limited, the broker tries another eligible backend; if none can run the allocation, the
+request fails fast with a rate-limit fallback exhaustion error instead of waiting in the queue.
 
 ## Warm Capacity
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,9 +46,10 @@ Queued admission is optional and disabled by default.
 
 When enabled, the broker stores retryable allocation failures as `pending`
 instead of failing the workflow immediately. Retryable failures include
-temporary provider dispatch errors, rate-limited backends, open backend
-circuits, and short capacity gaps. The queue reconciler retries pending
-allocations until they become `ready`, expire, or exhaust `maxAttempts`.
+temporary provider dispatch errors, open backend circuits, and short capacity
+gaps. Rate-limited backends are treated as fallback candidates first: the broker
+tries another eligible backend, and fails fast with a rate-limit exhaustion
+error when no fallback backend can run the allocation.
 
 ## Pools
 

--- a/internal/api/backend_admission.go
+++ b/internal/api/backend_admission.go
@@ -75,10 +75,15 @@ func newBackendAdmission() *backendAdmission {
 func (a *backendAdmission) filter(pool model.PoolConfig, request model.AllocationRequest, now time.Time) (model.PoolConfig, error) {
 	filtered := pool
 	filtered.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+	rateLimited := 0
 	for name, cfg := range pool.Backends {
 		decision := a.allow(pool.Name, name, cfg, now, false, false)
 		if decision.Allowed {
 			filtered.Backends[name] = cfg
+			continue
+		}
+		if decision.Reason == "rate-limited" {
+			rateLimited++
 		}
 	}
 
@@ -102,6 +107,9 @@ func (a *backendAdmission) filter(pool model.PoolConfig, request model.Allocatio
 	}
 
 	if len(filtered.Backends) == 0 {
+		if rateLimited == len(pool.Backends) {
+			return model.PoolConfig{}, fmt.Errorf("all eligible backends for pool %q are rate-limited: %w", pool.Name, ErrBackendRateLimited)
+		}
 		return model.PoolConfig{}, fmt.Errorf("%w for pool %q after backend admission filtering", scheduler.ErrNoCapacity, pool.Name)
 	}
 	return filtered, nil

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -201,7 +201,9 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 			return model.AllocationStatus{}, err
 		}
 	}
-	pool, err = s.filterBackendsByAdmission(pool, request)
+	pinnedBackend := request.Backend
+	var fallbackFromRateLimit bool
+	pool, request, fallbackFromRateLimit, err = s.filterBackendsByAdmission(pool, request)
 	if err != nil {
 		if queued, ok := s.queueAllocation(ctx, request, resultPool, "", err, existing); ok {
 			result = "queued"
@@ -218,43 +220,65 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 		return model.AllocationStatus{}, err
 	}
 
-	selected, err := s.reserve(pool, request)
-	if err != nil {
-		if queued, ok := s.queueAllocation(ctx, request, pool.Name, "", err, existing); ok {
-			result = "queued"
-			return queued, nil
+	reservePool := pool
+	reserveRequest := request
+	var selected model.BackendName
+	var rateLimitedFallback model.BackendName
+	for {
+		selected, err = s.reserve(reservePool, reserveRequest)
+		if err != nil {
+			if errors.Is(err, scheduler.ErrNoCapacity) {
+				if rateLimitedFallback != "" {
+					return model.AllocationStatus{}, fmt.Errorf("selected backend %q is rate-limited and no fallback backend is available: %w", rateLimitedFallback, ErrBackendRateLimited)
+				}
+				if fallbackFromRateLimit && pinnedBackend != nil {
+					return model.AllocationStatus{}, fmt.Errorf("pinned backend %q is rate-limited and no fallback backend is available: %w", *pinnedBackend, ErrBackendRateLimited)
+				}
+			}
+			if queued, ok := s.queueAllocation(ctx, reserveRequest, reservePool.Name, "", err, existing); ok {
+				result = "queued"
+				return queued, nil
+			}
+			return model.AllocationStatus{}, err
 		}
-		return model.AllocationStatus{}, err
-	}
-	if s.admission != nil {
-		decision := s.admission.allow(pool.Name, selected, pool.Backends[selected], s.now(), false, true)
+		if s.admission == nil {
+			pool = reservePool
+			request = reserveRequest
+			break
+		}
+		decision := s.admission.allow(reservePool.Name, selected, reservePool.Backends[selected], s.now(), false, true)
 		if !decision.Allowed {
-			s.release(context.Background(), pool, selected, model.AllocationStatus{Pool: pool.Name, SelectedBackend: selected})
-			s.observer.ObserveBackendAdmissionRejected(pool.Name, selected, decision.Reason)
+			s.release(context.Background(), reservePool, selected, model.AllocationStatus{Pool: reservePool.Name, SelectedBackend: selected})
+			s.observer.ObserveBackendAdmissionRejected(reservePool.Name, selected, decision.Reason)
 			switch decision.Reason {
 			case "circuit-open":
 				err := fmt.Errorf("selected backend %q is not admissible: %w", selected, ErrBackendCircuitOpen)
-				if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, existing); ok {
+				if queued, ok := s.queueAllocation(ctx, reserveRequest, reservePool.Name, selected, err, existing); ok {
 					result = "queued"
 					return queued, nil
 				}
 				return model.AllocationStatus{}, err
 			case "rate-limited":
-				err := fmt.Errorf("selected backend %q is not admissible: %w", selected, ErrBackendRateLimited)
-				if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, existing); ok {
-					result = "queued"
-					return queued, nil
+				rateLimitedFallback = selected
+				reservePool = withoutBackend(reservePool, selected)
+				reserveRequest.Backend = nil
+				if len(reservePool.Backends) > 0 {
+					continue
 				}
+				err := fmt.Errorf("selected backend %q is rate-limited and no fallback backend is available: %w", selected, ErrBackendRateLimited)
 				return model.AllocationStatus{}, err
 			default:
 				err := fmt.Errorf("selected backend %q is not admissible: %s", selected, decision.Reason)
-				if queued, ok := s.queueAllocation(ctx, request, pool.Name, selected, err, existing); ok {
+				if queued, ok := s.queueAllocation(ctx, reserveRequest, reservePool.Name, selected, err, existing); ok {
 					result = "queued"
 					return queued, nil
 				}
 				return model.AllocationStatus{}, err
 			}
 		}
+		pool = reservePool
+		request = reserveRequest
+		break
 	}
 	resultBackend = selected
 	s.observer.ObserveAllocationStart(pool.Name)
@@ -847,9 +871,9 @@ func (s *Service) reserveForBackend(pool model.PoolConfig, backendName model.Bac
 	return s.reserve(pool, request)
 }
 
-func (s *Service) filterBackendsByAdmission(pool model.PoolConfig, request model.AllocationRequest) (model.PoolConfig, error) {
+func (s *Service) filterBackendsByAdmission(pool model.PoolConfig, request model.AllocationRequest) (model.PoolConfig, model.AllocationRequest, bool, error) {
 	if s.admission == nil {
-		return pool, nil
+		return pool, request, false, nil
 	}
 	filtered, err := s.admission.filter(pool, request, s.now())
 	if err != nil {
@@ -859,9 +883,24 @@ func (s *Service) filterBackendsByAdmission(pool model.PoolConfig, request model
 				reason = "rate-limited"
 			}
 			s.observer.ObserveBackendAdmissionRejected(pool.Name, *request.Backend, reason)
+			if errors.Is(err, ErrBackendRateLimited) {
+				fallbackRequest := request
+				fallbackRequest.Backend = nil
+				fallback, fallbackErr := s.admission.filter(pool, fallbackRequest, s.now())
+				if fallbackErr == nil {
+					s.observeAdmissionRejections(pool, fallback)
+					return fallback, fallbackRequest, true, nil
+				}
+				return model.PoolConfig{}, request, false, fmt.Errorf("pinned backend %q is rate-limited and no fallback backend is available: %w", *request.Backend, fallbackErr)
+			}
 		}
-		return model.PoolConfig{}, err
+		return model.PoolConfig{}, request, false, err
 	}
+	s.observeAdmissionRejections(pool, filtered)
+	return filtered, request, false, nil
+}
+
+func (s *Service) observeAdmissionRejections(pool model.PoolConfig, filtered model.PoolConfig) {
 	for name := range pool.Backends {
 		if _, ok := filtered.Backends[name]; !ok {
 			decision := s.admission.allow(pool.Name, name, pool.Backends[name], s.now(), false, false)
@@ -870,7 +909,18 @@ func (s *Service) filterBackendsByAdmission(pool model.PoolConfig, request model
 			}
 		}
 	}
-	return filtered, nil
+}
+
+func withoutBackend(pool model.PoolConfig, name model.BackendName) model.PoolConfig {
+	filtered := pool
+	filtered.Backends = make(map[model.BackendName]model.BackendConfig, len(pool.Backends))
+	for candidate, cfg := range pool.Backends {
+		if candidate == name {
+			continue
+		}
+		filtered.Backends[candidate] = cfg
+	}
+	return filtered
 }
 
 func (s *Service) filterBackendsByTierState(pool model.PoolConfig, request model.AllocationRequest) (model.PoolConfig, error) {
@@ -1427,7 +1477,7 @@ func queueableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, scheduler.ErrNoCapacity) || errors.Is(err, ErrBackendRateLimited) || errors.Is(err, ErrBackendCircuitOpen) {
+	if errors.Is(err, scheduler.ErrNoCapacity) || errors.Is(err, ErrBackendCircuitOpen) {
 		return true
 	}
 	reason, ok := backend.FailureReason(err)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -821,7 +821,7 @@ func TestCompleteFailureClassOpensCircuit(t *testing.T) {
 	}
 }
 
-func TestRateLimitAppliesToSelectedColdBackendOnly(t *testing.T) {
+func TestRateLimitedPinnedBackendFallsBackToAnotherBackend(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {
 			return
@@ -838,6 +838,11 @@ func TestRateLimitAppliesToSelectedColdBackendOnly(t *testing.T) {
 		codebuildCfg.RateLimit.Permits = 1
 		codebuildCfg.RateLimit.Interval = time.Minute
 		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+		lambdaCfg := pool.Backends[model.BackendLambda]
+		lambdaCfg.Enabled = true
+		lambdaCfg.Healthy = true
+		lambdaCfg.MaxRunners = 1
+		pool.Backends[model.BackendLambda] = lambdaCfg
 	})
 	service.now = func() time.Time { return time.Unix(1000, 0) }
 
@@ -854,12 +859,71 @@ func TestRateLimitAppliesToSelectedColdBackendOnly(t *testing.T) {
 		t.Fatal("cancel failed")
 	}
 
-	if _, err := service.Allocate(context.Background(), model.AllocationRequest{
+	fallback, err := service.Allocate(context.Background(), model.AllocationRequest{
 		Pool:       model.PoolLite,
 		Backend:    &pinned,
 		JobTimeout: 5 * time.Minute,
-	}); !errors.Is(err, ErrBackendRateLimited) {
-		t.Fatalf("expected second allocation to be rate limited, got %v", err)
+	})
+	if err != nil {
+		t.Fatalf("expected second allocation to fall back from rate-limited pinned backend: %v", err)
+	}
+	if fallback.SelectedBackend != model.BackendLambda {
+		t.Fatalf("expected fallback backend %s, got %s", model.BackendLambda, fallback.SelectedBackend)
+	}
+}
+
+func TestRateLimitedPinnedBackendFailsFastWhenNoFallbackBackendAvailable(t *testing.T) {
+	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
+		cfg.Broker.Queue.Enabled = true
+		for index := range cfg.Pools {
+			pool := &cfg.Pools[index]
+			if pool.Name != model.PoolLite {
+				continue
+			}
+			for name, backendCfg := range pool.Backends {
+				backendCfg.Enabled = false
+				pool.Backends[name] = backendCfg
+			}
+			codebuildCfg := pool.Backends[model.BackendCodeBuild]
+			codebuildCfg.Enabled = true
+			codebuildCfg.Healthy = true
+			codebuildCfg.MaxRunners = 1
+			codebuildCfg.RateLimit.Enabled = true
+			codebuildCfg.RateLimit.Permits = 1
+			codebuildCfg.RateLimit.Interval = time.Minute
+			pool.Backends[model.BackendCodeBuild] = codebuildCfg
+		}
+	})
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+
+	pinned := model.BackendCodeBuild
+	allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		Backend:    &pinned,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("first allocation failed: %v", err)
+	}
+	if _, ok := service.Cancel(allocation.ID); !ok {
+		t.Fatal("cancel failed")
+	}
+
+	_, err = service.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		Backend:    &pinned,
+		JobTimeout: 5 * time.Minute,
+	})
+	if !errors.Is(err, ErrBackendRateLimited) {
+		t.Fatalf("expected rate limit error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no fallback backend is available") {
+		t.Fatalf("expected explicit fallback exhaustion message, got %v", err)
+	}
+	for _, status := range service.store.List() {
+		if status.State == model.StatePending {
+			t.Fatalf("rate-limited fallback exhaustion should fail fast, got pending allocation %+v", status)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- fall back to another eligible backend when a selected or pinned backend is rate-limited
- fail fast with an explicit rate-limit fallback exhaustion error when no backend remains
- document the rate-limit fallback/queue contract and cover it in backend admission tests

## Tests
- go test ./internal/api -run 'RateLimit|RateLimited' -v
- go test ./...
- go test ./internal/api ./internal/backend/externaldispatch ./internal/scheduler -run "Test.*Circuit|Test.*Breaker|Test.*Probe|Test.*Timeout|Test.*RateLimit" -count=1

No GitHub issue was specified for this UECB repo change.