### PR TITLE
Clarify rate-limit fallback docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ into scheduler accounting so a restarted broker does not over-admit capacity.
 ### Queued Admission
 
 Queued admission is disabled by default. When enabled, retryable allocation
-failures such as no capacity, backend rate limiting, open backend circuits, or
-transient provider dispatch failures are stored as `pending` allocations.
+failures such as no capacity, open backend circuits, or transient provider
+dispatch failures are stored as `pending` allocations. Cold-launch rate limits
+are handled separately: the broker tries another eligible backend immediately
+and returns a direct error when no fallback backend can admit the request.
 
 ```yaml
 broker:
@@ -366,9 +368,17 @@ pools:
           recoverySuccessThreshold: 1
 ```
 
-`rateLimit` applies only to cold provisioning attempts. Warm runner reuse is not rate limited. When a cold
-backend is rate-limited, the broker tries another eligible backend; if none can run the allocation, the
-request fails fast with a rate-limit fallback exhaustion error instead of waiting in the queue.
+`rateLimit` applies only to cold provisioning attempts. Warm runner reuse is
+not rate limited, and each cold launch attempt consumes a permit even if the
+allocation is later canceled or fails downstream. When a cold backend is
+rate-limited, the broker tries another eligible backend; if none can run the
+allocation, the request fails fast with a rate-limit fallback exhaustion error
+instead of waiting in the queue.
+
+Unlike circuit-open or tier-policy rejections, rate limiting can still redirect
+a pinned request to another eligible backend. Pinning remains a preference for
+the first cold-launch attempt, not a guarantee that a rate-limited backend will
+be retried in place.
 
 ## Warm Capacity
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,9 +47,9 @@ Queued admission is optional and disabled by default.
 When enabled, the broker stores retryable allocation failures as `pending`
 instead of failing the workflow immediately. Retryable failures include
 temporary provider dispatch errors, open backend circuits, and short capacity
-gaps. Rate-limited backends are treated as fallback candidates first: the broker
-tries another eligible backend, and fails fast with a rate-limit exhaustion
-error when no fallback backend can run the allocation.
+gaps. Rate-limited backends are treated as fallback candidates first and are
+not queued: the broker tries another eligible backend, then fails fast with a
+rate-limit exhaustion error when no fallback backend can run the allocation.
 
 ## Pools
 
@@ -71,6 +71,12 @@ Backends may opt into runtime admission controls with `circuitBreaker` and `rate
 Admission order is deterministic: static `enabled`/`healthy`, capability filtering, requested timeout filtering, runtime circuit and cold-launch rate limiting, scheduler reservation, then backend provisioning.
 
 Circuit state is in-memory and scoped to a single `pool/backend` within one broker process. Keep broker replicas at `1` for this feature unless scheduler, allocation, and admission state are moved to shared storage together. Timeout-like provision failures, throttling, server errors, explicit `failure_class` completion callbacks, and allocation expiry can open the circuit for the failing backend only. Open backends are skipped for unpinned requests so another eligible backend can serve the allocation; pinned requests fail fast with a circuit-open error.
+
+Rate limiting only applies to cold launches. The broker consumes permits during
+admission, skips rate-limited backends for the current attempt, and may route a
+pinned request to another eligible backend when the pinned backend is
+throttled. If every remaining backend is rate-limited, the broker returns an
+explicit rate-limit exhaustion error instead of creating a pending allocation.
 
 The background backend-health loop probes open circuits and closes them after the configured recovery threshold. Backends without a probe implementation recover through the same success path once the circuit admits a half-open request.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -55,6 +55,12 @@ High allocation failure rate means requests are being rejected or backend provis
 
 Open backend circuits mean the broker is intentionally draining a backend after repeated timeout, wait, throttling, transport, or server-error signals. Check `uecb_backend_circuit_transitions_total` for the trip reason and `uecb_backend_probe_results_total` for recovery progress.
 
+High `uecb_backend_admission_rejections_total{reason="rate-limited"}` with
+flat `uecb_queue_depth` means cold-launch permits are being exhausted before
+the queue path is reached. Expect immediate allocation errors when no fallback
+backend remains; check whether another backend should be enabled, warm capacity
+should be raised, or the backend `rateLimit` should be relaxed.
+
 Tier fallback activity means all eligible cloud backends were unavailable under the current tier policy or tier data was stale/unknown. Check `uecb_tier_state` first, then validate the Prometheus recording rules and provider budget/free-tier/credit API responses that feed the cache.
 
 Saturated capacity means the scheduler has few or no healthy slots available for a pool/backend. Check `maxRunners`, runner cleanup, and whether completed jobs are leaving allocations in `ready` or `reserved`.


### PR DESCRIPTION
## Summary
- clarify that queued admission does not queue pure rate-limit exhaustion
- document that cold-launch rate limits immediately try fallback backends, including pinned requests
- add operator guidance for rate-limit admission rejections in observability docs

## Tests
- git diff --check
- go test ./internal/api -run 'RateLimit|RateLimited'

Follow-up docs for PR #42.