### PR TITLE
Fail fast on rate-limited backend exhaustion

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1477,6 +1477,9 @@ func queueableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, ErrBackendRateLimited) {
+		return false
+	}
 	if errors.Is(err, scheduler.ErrNoCapacity) || errors.Is(err, ErrBackendCircuitOpen) {
 		return true
 	}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -927,6 +927,13 @@ func TestRateLimitedPinnedBackendFailsFastWhenNoFallbackBackendAvailable(t *test
 	}
 }
 
+func TestRateLimitedErrorsAreNotQueued(t *testing.T) {
+	err := fmt.Errorf("pinned backend %q is rate-limited and no fallback backend is available: %w", model.BackendLambda, ErrBackendRateLimited)
+	if queueableError(err) {
+		t.Fatalf("rate-limited fallback exhaustion must fail fast instead of entering the admission queue")
+	}
+}
+
 func TestHalfOpenAdmissionDoesNotConsumeProbeSlotDuringFiltering(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name != model.PoolLite {


### PR DESCRIPTION
## Summary
- keep rate-limit fallback exhaustion out of the admission queue
- add a regression test that rate-limited no-fallback errors are not queueable

## Validation
- `go test ./internal/api -run 'TestRateLimitedPinnedBackendFailsFastWhenNoFallbackBackendAvailable|TestRateLimitedErrorsAreNotQueued|TestRateLimitedPinnedBackendFallsBack' -count=1`\n- `go test ./...`\n\nRelated: Josh-Archer/home#1621