### PR TITLE
Fail fast when runner capacity is exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ into scheduler accounting so a restarted broker does not over-admit capacity.
 ### Queued Admission
 
 Queued admission is disabled by default. When enabled, retryable allocation
-failures such as no capacity, open backend circuits, or transient provider
-dispatch failures are stored as `pending` allocations. Cold-launch rate limits
-are handled separately: the broker tries another eligible backend immediately
-and returns a direct error when no fallback backend can admit the request.
+failures such as open backend circuits or transient provider dispatch failures
+are stored as `pending` allocations. Capacity exhaustion and cold-launch rate
+limits fail fast instead of entering the queue: rate-limited backends are
+skipped in favor of another eligible backend, and the broker returns a direct
+error when no backend can admit the request.
 
 ```yaml
 broker:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,10 @@ Queued admission is optional and disabled by default.
 
 When enabled, the broker stores retryable allocation failures as `pending`
 instead of failing the workflow immediately. Retryable failures include
-temporary provider dispatch errors, open backend circuits, and short capacity
-gaps. Rate-limited backends are treated as fallback candidates first and are
-not queued: the broker tries another eligible backend, then fails fast with a
-rate-limit exhaustion error when no fallback backend can run the allocation.
+temporary provider dispatch errors and open backend circuits. Capacity
+exhaustion and rate-limited backends are not queued: the broker tries another
+eligible backend when rate limits block the selected backend, then fails fast
+when no backend can run the allocation.
 
 ## Pools
 

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -77,33 +77,29 @@ func TestHandleAllocationsAcceptsStringJobTimeout(t *testing.T) {
 	}
 }
 
-func TestHandleAllocationsReturnsAcceptedForQueuedAllocation(t *testing.T) {
-	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
-		cfg.Broker.Queue.Enabled = true
-		cfg.Broker.Queue.RetryAfter = time.Second
-		cfg.Pools[0].Backends[model.BackendARC] = model.BackendConfig{
-			Enabled:    true,
-			Healthy:    true,
-			MaxRunners: 1,
-			Template:   "arc-full",
-		}
-	})
+func TestHandleAllocationsReturnsAcceptedForQueuedTransientFailure(t *testing.T) {
+	cfg := config.Default()
+	cfg.Broker.Queue.Enabled = true
+	cfg.Broker.Queue.RetryAfter = time.Second
+	cfg.Pools[0].Backends[model.BackendARC] = model.BackendConfig{
+		Enabled:    true,
+		Healthy:    true,
+		MaxRunners: 1,
+		Template:   "arc-full",
+	}
+	service := NewService(cfg, backend.NewRegistry(&sequenceBackend{
+		testBackend: testBackend{name: model.BackendARC},
+		errs:        []error{backend.NewClassifiedError(backend.FailureReasonTransport, errors.New("temporary transport failure"))},
+	}), nil)
 	service.now = func() time.Time { return time.Unix(1000, 0) }
 	server := newTestServer(t, service)
 	handler := server.Handler()
-
-	first := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
-	firstRecorder := httptest.NewRecorder()
-	handler.ServeHTTP(firstRecorder, first)
-	if firstRecorder.Code != http.StatusCreated {
-		t.Fatalf("expected first allocation to succeed, got %d: %s", firstRecorder.Code, firstRecorder.Body.String())
-	}
 
 	second := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
 	secondRecorder := httptest.NewRecorder()
 	handler.ServeHTTP(secondRecorder, second)
 	if secondRecorder.Code != http.StatusAccepted {
-		t.Fatalf("expected queued allocation to return 202, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
+		t.Fatalf("expected queued transient failure to return 202, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
 	}
 	if secondRecorder.Header().Get("Retry-After") == "" {
 		t.Fatalf("expected Retry-After header for queued allocation")

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1480,7 +1480,10 @@ func queueableError(err error) bool {
 	if errors.Is(err, ErrBackendRateLimited) {
 		return false
 	}
-	if errors.Is(err, scheduler.ErrNoCapacity) || errors.Is(err, ErrBackendCircuitOpen) {
+	if errors.Is(err, scheduler.ErrNoCapacity) {
+		return false
+	}
+	if errors.Is(err, ErrBackendCircuitOpen) {
 		return true
 	}
 	reason, ok := backend.FailureReason(err)

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -291,7 +291,7 @@ func TestFileStoreRehydrateExpiresPastDeadlineAllocation(t *testing.T) {
 	}
 }
 
-func TestQueuePendingAllocationRetriesAfterCapacityIsReleased(t *testing.T) {
+func TestNoCapacityFailsFastInsteadOfEnteringQueue(t *testing.T) {
 	now := time.Unix(2000, 0)
 	service := newServiceWithBrokerConfig(func(cfg *model.BrokerConfig) {
 		cfg.Broker.Queue.Enabled = true
@@ -306,32 +306,21 @@ func TestQueuePendingAllocationRetriesAfterCapacityIsReleased(t *testing.T) {
 	})
 	service.now = func() time.Time { return now }
 
-	first, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
+	_, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
 	if err != nil {
 		t.Fatalf("first allocate: %v", err)
 	}
-	pending, err := service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
-	if err != nil {
-		t.Fatalf("expected second allocation to queue, got %v", err)
+	_, err = service.Allocate(context.Background(), model.AllocationRequest{Pool: model.PoolFull, JobTimeout: time.Minute})
+	if !errors.Is(err, scheduler.ErrNoCapacity) {
+		t.Fatalf("expected no-capacity error, got %v", err)
 	}
-	if pending.State != model.StatePending {
-		t.Fatalf("expected pending state, got %s", pending.State)
+	if queueableError(err) {
+		t.Fatalf("no-capacity exhaustion must fail fast instead of entering the admission queue")
 	}
-
-	service.Cancel(first.ID)
-	now = now.Add(2 * time.Second)
-	if updated := service.ReconcileQueue(context.Background(), now); updated != 1 {
-		t.Fatalf("expected one queued allocation to reconcile, got %d", updated)
-	}
-	retried, ok := service.Get(pending.ID)
-	if !ok {
-		t.Fatal("expected queued allocation to still exist")
-	}
-	if retried.State != model.StateReady {
-		t.Fatalf("expected queued allocation to become ready, got %+v", retried)
-	}
-	if retried.Attempts != 1 {
-		t.Fatalf("expected one retry attempt, got %d", retried.Attempts)
+	for _, status := range service.store.List() {
+		if status.State == model.StatePending {
+			t.Fatalf("no-capacity exhaustion should fail fast, got pending allocation %+v", status)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop queuing scheduler no-capacity errors so exhausted runner pools fail fast with a clear error
- keep admission queue behavior for transient provider failures and open circuits
- update API/docs tests to cover no-capacity fail-fast and transient queue behavior

Related to Josh-Archer/home#1621.

## Tests
- `/mnt/c/Program Files/Go/bin/go.exe test ./internal/api -run 'TestNoCapacityFailsFastInsteadOfEnteringQueue|TestQueueRetriesTransientBackendFailure|TestHandleAllocationsReturnsAcceptedForQueuedTransientFailure|TestRateLimitedPinnedBackendFailsFastWhenNoFallbackBackendAvailable|TestRateLimitedErrorsAreNotQueued' -count=1`\n- `/mnt/c/Program Files/Go/bin/go.exe test ./...`