### PR TITLE
fix: verify GitHub OIDC JWT signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,24 @@ See [docs/architecture.md](docs/architecture.md) and [docs/security-boundary.md]
 3. Point the `allocate-runner` action at the broker URL. The broker accepts `job_timeout` in the same duration-string format used by the action, for example `15m`.
 4. Start with the `full` pool or ARC-only `lite` pool. Only enable an external backend after you have supplied a real launcher integration for that platform and the matching `secretRef`.
 
+## Broker OIDC Authentication
+
+When `broker.allowUnauthenticated` is false, allocation and completion requests
+must use `Authorization: Bearer <token>` with a GitHub Actions OIDC token. The
+broker discovers GitHub's JWKS from
+`https://token.actions.githubusercontent.com/.well-known/openid-configuration`,
+caches signing keys, and accepts only RS256 tokens signed by that issuer.
+
+The token must include:
+
+- `iss`: `https://token.actions.githubusercontent.com`
+- `aud`: the configured `broker.api.oidcAudience` value, `uecb-broker` by default
+- `sub`: a non-empty GitHub Actions subject such as `repo:OWNER/REPO:ref:...`
+- current `exp` and, when present, `nbf` claims
+
+Set `broker.allowUnauthenticated: true` only behind a separate trusted network
+or gateway boundary.
+
 ## Azure Functions Launcher
 
 The published Azure Functions launcher image lives in `docker/azure-functions` and is designed for a Linux custom-container Function App.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,8 @@
 - The broker runs in Kubernetes.
 - GitHub workflows call the `allocate-runner` action.
 - The action exchanges OIDC identity for a broker allocation request.
+- The broker verifies GitHub Actions OIDC tokens through the issuer discovery
+  document and JWKS before authorizing allocation or completion requests.
 - The broker selects a backend, reserves capacity, provisions a runner, and returns the label that the heavy job should target.
 - External backends read `dispatch_url` and optional `dispatch_token` from their configured `secretRef` and hand off provisioning to a provider-owned controller.
 - Provider-owned controllers can use the public `pkg/adapter` SDK and `pkg/adapter/adaptertest` conformance harness to keep health, capacity, reserve, launch, and cleanup behavior aligned with the broker contract.

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,42 +1,160 @@
 package api
 
 import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"net/http"
 	"strings"
+	"sync"
+	"time"
 )
+
+const oidcCacheTTL = time.Hour
 
 var (
 	ErrMissingBearerToken = errors.New("missing bearer token")
+	ErrInvalidBearerToken = errors.New("invalid bearer token")
 	ErrInvalidAudience    = errors.New("invalid oidc audience")
 	ErrInvalidIssuer      = errors.New("invalid oidc issuer")
 	ErrInvalidSubject     = errors.New("missing oidc subject")
+	ErrInvalidToken       = errors.New("invalid oidc token")
+	ErrInvalidSignature   = errors.New("invalid oidc token signature")
+	ErrTokenExpired       = errors.New("expired oidc token")
+	ErrTokenNotValidYet   = errors.New("oidc token not valid yet")
 )
 
 type OIDCClaims struct {
 	Iss string      `json:"iss"`
 	Aud interface{} `json:"aud"`
 	Sub string      `json:"sub"`
+	Exp int64       `json:"exp"`
+	Nbf int64       `json:"nbf,omitempty"`
 }
 
-func ExtractClaimsUnverified(rawToken string) (OIDCClaims, error) {
-	parts := strings.Split(rawToken, ".")
-	if len(parts) != 3 {
-		return OIDCClaims{}, fmt.Errorf("expected JWT with three parts")
-	}
+type OIDCVerifier struct {
+	client *http.Client
+	now    func() time.Time
 
-	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	mu        sync.Mutex
+	discovery map[string]cachedDiscovery
+	keys      map[string]cachedJWKS
+}
+
+type cachedDiscovery struct {
+	jwksURI string
+	expires time.Time
+}
+
+type cachedJWKS struct {
+	keys    []jwkKey
+	expires time.Time
+}
+
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+	Typ string `json:"typ,omitempty"`
+}
+
+type discoveryDocument struct {
+	JWKSURI string `json:"jwks_uri"`
+}
+
+type jwksDocument struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+type jwkKey struct {
+	Kty string `json:"kty"`
+	Use string `json:"use,omitempty"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg,omitempty"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func NewOIDCVerifier() *OIDCVerifier {
+	return &OIDCVerifier{
+		client:    http.DefaultClient,
+		now:       time.Now,
+		discovery: make(map[string]cachedDiscovery),
+		keys:      make(map[string]cachedJWKS),
+	}
+}
+
+func (v *OIDCVerifier) VerifyToken(ctx context.Context, rawToken string, expectedAudience string, allowedIssuers []string) (OIDCClaims, error) {
+	header, claims, signingInput, signature, err := parseJWT(rawToken)
 	if err != nil {
 		return OIDCClaims{}, err
 	}
-
-	var claims OIDCClaims
-	if err := json.Unmarshal(decoded, &claims); err != nil {
+	if header.Alg != "RS256" || header.Kid == "" {
+		return OIDCClaims{}, ErrInvalidToken
+	}
+	if err := ValidateOIDCClaims(claims, expectedAudience, allowedIssuers); err != nil {
 		return OIDCClaims{}, err
 	}
+	if err := validateOIDCTimeClaims(claims, v.now()); err != nil {
+		return OIDCClaims{}, err
+	}
+
+	jwksURI, err := v.jwksURI(ctx, claims.Iss)
+	if err != nil {
+		return OIDCClaims{}, err
+	}
+	key, err := v.signingKey(ctx, jwksURI, header.Kid, false)
+	if err != nil {
+		return OIDCClaims{}, err
+	}
+	if err := verifyRS256(signingInput, signature, key); err != nil {
+		key, refreshErr := v.signingKey(ctx, jwksURI, header.Kid, true)
+		if refreshErr != nil {
+			return OIDCClaims{}, refreshErr
+		}
+		if retryErr := verifyRS256(signingInput, signature, key); retryErr != nil {
+			return OIDCClaims{}, retryErr
+		}
+	}
+
 	return claims, nil
+}
+
+func parseJWT(rawToken string) (jwtHeader, OIDCClaims, []byte, []byte, error) {
+	parts := strings.Split(rawToken, ".")
+	if len(parts) != 3 {
+		return jwtHeader{}, OIDCClaims{}, nil, nil, fmt.Errorf("%w: expected JWT with three parts", ErrInvalidToken)
+	}
+
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return jwtHeader{}, OIDCClaims{}, nil, nil, fmt.Errorf("%w: decode header: %v", ErrInvalidToken, err)
+	}
+	var header jwtHeader
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return jwtHeader{}, OIDCClaims{}, nil, nil, fmt.Errorf("%w: decode header: %v", ErrInvalidToken, err)
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return jwtHeader{}, OIDCClaims{}, nil, nil, fmt.Errorf("%w: decode claims: %v", ErrInvalidToken, err)
+	}
+	var claims OIDCClaims
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return jwtHeader{}, OIDCClaims{}, nil, nil, fmt.Errorf("%w: decode claims: %v", ErrInvalidToken, err)
+	}
+
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return jwtHeader{}, OIDCClaims{}, nil, nil, fmt.Errorf("%w: decode signature: %v", ErrInvalidToken, err)
+	}
+
+	return header, claims, []byte(parts[0] + "." + parts[1]), signature, nil
 }
 
 func ValidateOIDCClaims(claims OIDCClaims, expectedAudience string, allowedIssuers []string) error {
@@ -48,15 +166,24 @@ func ValidateOIDCClaims(claims OIDCClaims, expectedAudience string, allowedIssue
 		return ErrInvalidAudience
 	}
 
-	if len(allowedIssuers) > 0 {
-		for _, issuer := range allowedIssuers {
-			if claims.Iss == issuer {
-				return nil
-			}
-		}
+	if len(allowedIssuers) == 0 {
 		return ErrInvalidIssuer
 	}
+	for _, issuer := range allowedIssuers {
+		if claims.Iss == issuer {
+			return nil
+		}
+	}
+	return ErrInvalidIssuer
+}
 
+func validateOIDCTimeClaims(claims OIDCClaims, now time.Time) error {
+	if claims.Exp == 0 || !now.Before(time.Unix(claims.Exp, 0)) {
+		return ErrTokenExpired
+	}
+	if claims.Nbf != 0 && now.Before(time.Unix(claims.Nbf, 0)) {
+		return ErrTokenNotValidYet
+	}
 	return nil
 }
 
@@ -72,4 +199,127 @@ func audienceMatches(value interface{}, expected string) bool {
 		}
 	}
 	return false
+}
+
+func (v *OIDCVerifier) jwksURI(ctx context.Context, issuer string) (string, error) {
+	now := v.now()
+
+	v.mu.Lock()
+	if cached, ok := v.discovery[issuer]; ok && now.Before(cached.expires) {
+		v.mu.Unlock()
+		return cached.jwksURI, nil
+	}
+	v.mu.Unlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(issuer, "/")+"/.well-known/openid-configuration", nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := v.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("oidc discovery status %d", res.StatusCode)
+	}
+
+	var doc discoveryDocument
+	if err := json.NewDecoder(res.Body).Decode(&doc); err != nil {
+		return "", err
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("%w: discovery document missing jwks_uri", ErrInvalidToken)
+	}
+
+	v.mu.Lock()
+	v.discovery[issuer] = cachedDiscovery{jwksURI: doc.JWKSURI, expires: now.Add(oidcCacheTTL)}
+	v.mu.Unlock()
+
+	return doc.JWKSURI, nil
+}
+
+func (v *OIDCVerifier) signingKey(ctx context.Context, jwksURI, kid string, forceRefresh bool) (*rsa.PublicKey, error) {
+	keys, err := v.jwks(ctx, jwksURI, forceRefresh)
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range keys {
+		if key.Kid != kid {
+			continue
+		}
+		if key.Kty != "RSA" || (key.Use != "" && key.Use != "sig") || (key.Alg != "" && key.Alg != "RS256") {
+			return nil, ErrInvalidToken
+		}
+		return rsaPublicKey(key)
+	}
+	if !forceRefresh {
+		return v.signingKey(ctx, jwksURI, kid, true)
+	}
+	return nil, fmt.Errorf("%w: signing key not found", ErrInvalidSignature)
+}
+
+func (v *OIDCVerifier) jwks(ctx context.Context, jwksURI string, forceRefresh bool) ([]jwkKey, error) {
+	now := v.now()
+
+	v.mu.Lock()
+	if cached, ok := v.keys[jwksURI]; ok && !forceRefresh && now.Before(cached.expires) {
+		v.mu.Unlock()
+		return cached.keys, nil
+	}
+	v.mu.Unlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := v.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jwks status %d", res.StatusCode)
+	}
+
+	var doc jwksDocument
+	if err := json.NewDecoder(res.Body).Decode(&doc); err != nil {
+		return nil, err
+	}
+	if len(doc.Keys) == 0 {
+		return nil, fmt.Errorf("%w: jwks has no keys", ErrInvalidToken)
+	}
+
+	v.mu.Lock()
+	v.keys[jwksURI] = cachedJWKS{keys: doc.Keys, expires: now.Add(oidcCacheTTL)}
+	v.mu.Unlock()
+
+	return doc.Keys, nil
+}
+
+func rsaPublicKey(key jwkKey) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(key.N)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid rsa modulus", ErrInvalidToken)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(key.E)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid rsa exponent", ErrInvalidToken)
+	}
+	exponent := 0
+	for _, b := range eBytes {
+		exponent = exponent<<8 + int(b)
+	}
+	if exponent == 0 {
+		return nil, fmt.Errorf("%w: invalid rsa exponent", ErrInvalidToken)
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nBytes), E: exponent}, nil
+}
+
+func verifyRS256(signingInput, signature []byte, key *rsa.PublicKey) error {
+	digest := sha256.Sum256(signingInput)
+	if err := rsa.VerifyPKCS1v15(key, crypto.SHA256, digest[:], signature); err != nil {
+		return ErrInvalidSignature
+	}
+	return nil
 }

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,25 +1,96 @@
 package api
 
 import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
-func buildToken(payload string) string {
-	return fmt.Sprintf("header.%s.signature", base64.RawURLEncoding.EncodeToString([]byte(payload)))
+func TestVerifyTokenAcceptsSignedGitHubOIDCToken(t *testing.T) {
+	key := mustRSAKey(t)
+	issuer := newOIDCTestIssuer(t, key, "test-key")
+	now := time.Unix(2000, 0)
+	token := signedOIDCToken(t, key, "test-key", OIDCClaims{
+		Iss: issuer.URL,
+		Aud: "uecb-broker",
+		Sub: "repo:example/repo:ref",
+		Exp: now.Add(time.Hour).Unix(),
+		Nbf: now.Add(-time.Minute).Unix(),
+	})
+
+	verifier := NewOIDCVerifier()
+	verifier.now = func() time.Time { return now }
+
+	claims, err := verifier.VerifyToken(context.Background(), token, "uecb-broker", []string{issuer.URL})
+	if err != nil {
+		t.Fatalf("expected signed token to verify: %v", err)
+	}
+	if claims.Sub != "repo:example/repo:ref" {
+		t.Fatalf("unexpected subject %q", claims.Sub)
+	}
 }
 
-func TestExtractClaimsUnverified(t *testing.T) {
-	token := buildToken(`{"iss":"https://token.actions.githubusercontent.com","aud":"uecb-broker","sub":"repo:example/repo:ref"}`)
+func TestVerifyTokenRejectsForgedThreePartToken(t *testing.T) {
+	key := mustRSAKey(t)
+	issuer := newOIDCTestIssuer(t, key, "test-key")
+	now := time.Unix(2000, 0)
+	payload := fmt.Sprintf(`{"iss":%q,"aud":"uecb-broker","sub":"repo:example/repo:ref","exp":%d}`, issuer.URL, now.Add(time.Hour).Unix())
+	token := fmt.Sprintf("header.%s.signature", base64.RawURLEncoding.EncodeToString([]byte(payload)))
 
-	claims, err := ExtractClaimsUnverified(token)
-	if err != nil {
-		t.Fatalf("extract failed: %v", err)
+	verifier := NewOIDCVerifier()
+	verifier.now = func() time.Time { return now }
+
+	if _, err := verifier.VerifyToken(context.Background(), token, "uecb-broker", []string{issuer.URL}); !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("expected invalid token error for forged header, got %v", err)
 	}
+}
 
-	if claims.Iss != "https://token.actions.githubusercontent.com" || claims.Sub == "" {
-		t.Fatalf("unexpected claims: %#v", claims)
+func TestVerifyTokenRejectsTamperedSignature(t *testing.T) {
+	key := mustRSAKey(t)
+	issuer := newOIDCTestIssuer(t, key, "test-key")
+	now := time.Unix(2000, 0)
+	token := signedOIDCToken(t, key, "test-key", OIDCClaims{
+		Iss: issuer.URL,
+		Aud: "uecb-broker",
+		Sub: "repo:example/repo:ref",
+		Exp: now.Add(time.Hour).Unix(),
+	})
+	token += "tamper"
+
+	verifier := NewOIDCVerifier()
+	verifier.now = func() time.Time { return now }
+
+	if _, err := verifier.VerifyToken(context.Background(), token, "uecb-broker", []string{issuer.URL}); !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("expected invalid signature error, got %v", err)
+	}
+}
+
+func TestVerifyTokenRejectsExpiredToken(t *testing.T) {
+	key := mustRSAKey(t)
+	issuer := newOIDCTestIssuer(t, key, "test-key")
+	now := time.Unix(2000, 0)
+	token := signedOIDCToken(t, key, "test-key", OIDCClaims{
+		Iss: issuer.URL,
+		Aud: "uecb-broker",
+		Sub: "repo:example/repo:ref",
+		Exp: now.Add(-time.Second).Unix(),
+	})
+
+	verifier := NewOIDCVerifier()
+	verifier.now = func() time.Time { return now }
+
+	if _, err := verifier.VerifyToken(context.Background(), token, "uecb-broker", []string{issuer.URL}); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("expected expired token error, got %v", err)
 	}
 }
 
@@ -37,4 +108,78 @@ func TestValidateOIDCClaims(t *testing.T) {
 	if err := ValidateOIDCClaims(claims, "different", []string{"https://token.actions.githubusercontent.com"}); err != ErrInvalidAudience {
 		t.Fatalf("expected invalid audience error, got %v", err)
 	}
+}
+
+func mustRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func newOIDCTestIssuer(t *testing.T, key *rsa.PrivateKey, kid string) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"jwks_uri": server.URL + "/.well-known/jwks",
+		})
+	})
+	mux.HandleFunc("/.well-known/jwks", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwksDocument{
+			Keys: []jwkKey{{
+				Kty: "RSA",
+				Use: "sig",
+				Kid: kid,
+				Alg: "RS256",
+				N:   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+				E:   base64.RawURLEncoding.EncodeToString(bigEndianInt(key.PublicKey.E)),
+			}},
+		})
+	})
+
+	return server
+}
+
+func signedOIDCToken(t *testing.T, key *rsa.PrivateKey, kid string, claims OIDCClaims) string {
+	t.Helper()
+
+	headerBytes, err := json.Marshal(jwtHeader{Alg: "RS256", Kid: kid, Typ: "JWT"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := base64.RawURLEncoding.EncodeToString(headerBytes)
+	payload := base64.RawURLEncoding.EncodeToString(claimsBytes)
+	signingInput := []byte(header + "." + payload)
+	digest := sha256.Sum256(signingInput)
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return header + "." + payload + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func bigEndianInt(value int) []byte {
+	if value == 0 {
+		return []byte{0}
+	}
+	var encoded []byte
+	for value > 0 {
+		encoded = append([]byte{byte(value)}, encoded...)
+		value >>= 8
+	}
+	return encoded
 }

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -18,6 +18,7 @@ type Server struct {
 	allowedIssuers []string
 	expectedAud    string
 	allowAnon      bool
+	oidcVerifier   *OIDCVerifier
 	requests       *prometheus.CounterVec
 }
 
@@ -33,6 +34,7 @@ func NewServer(service *Service, allowedIssuers []string, expectedAud string, al
 		allowedIssuers: allowedIssuers,
 		expectedAud:    expectedAud,
 		allowAnon:      allowAnon,
+		oidcVerifier:   NewOIDCVerifier(),
 		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "uecb_http_requests_total",
 			Help: "HTTP requests handled by the broker.",
@@ -184,12 +186,15 @@ func (s *Server) authorize(r *http.Request) error {
 		return ErrMissingBearerToken
 	}
 
-	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
-	claims, err := ExtractClaimsUnverified(token)
-	if err != nil {
-		return err
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return ErrInvalidBearerToken
 	}
-	return ValidateOIDCClaims(claims, s.expectedAud, s.allowedIssuers)
+	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+	if token == "" {
+		return ErrInvalidBearerToken
+	}
+	_, err := s.oidcVerifier.VerifyToken(r.Context(), token, s.expectedAud, s.allowedIssuers)
+	return err
 }
 
 func (s *Server) writeError(w http.ResponseWriter, code int, err error) {

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -3,8 +3,11 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -38,6 +41,18 @@ func newTestServer(t *testing.T, service *Service) *Server {
 	})
 
 	return NewServer(service, nil, "", true)
+}
+
+func configureSignedOIDC(t *testing.T, server *Server, key *rsa.PrivateKey, kid string, now time.Time) *httptest.Server {
+	t.Helper()
+
+	issuer := newOIDCTestIssuer(t, key, kid)
+	server.allowAnon = false
+	server.allowedIssuers = []string{issuer.URL}
+	server.expectedAud = "uecb-broker"
+	server.oidcVerifier = NewOIDCVerifier()
+	server.oidcVerifier.now = func() time.Time { return now }
+	return issuer
 }
 
 func TestHandleAllocationsAcceptsStringJobTimeout(t *testing.T) {
@@ -110,6 +125,50 @@ func TestHandleAllocationsReturnsAcceptedForQueuedTransientFailure(t *testing.T)
 	}
 	if allocation.State != model.StatePending {
 		t.Fatalf("expected pending state, got %+v", allocation)
+	}
+}
+
+func TestHandleAllocationsRejectsForgedOIDCToken(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	server := newTestServer(t, service)
+	now := time.Unix(2000, 0)
+	issuer := configureSignedOIDC(t, server, mustRSAKey(t), "test-key", now)
+
+	payload := fmt.Sprintf(`{"iss":%q,"aud":"uecb-broker","sub":"repo:example/repo:ref","exp":%d}`, issuer.URL, now.Add(time.Hour).Unix())
+	token := fmt.Sprintf("header.%s.signature", base64.RawURLEncoding.EncodeToString([]byte(payload)))
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	request.Header.Set("Authorization", "Bearer "+token)
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected forged token to return 401, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestHandleAllocationsAcceptsSignedOIDCToken(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+	server := newTestServer(t, service)
+	now := time.Unix(2000, 0)
+	key := mustRSAKey(t)
+	issuer := configureSignedOIDC(t, server, key, "test-key", now)
+	token := signedOIDCToken(t, key, "test-key", OIDCClaims{
+		Iss: issuer.URL,
+		Aud: "uecb-broker",
+		Sub: "repo:example/repo:ref",
+		Exp: now.Add(time.Hour).Unix(),
+		Nbf: now.Add(-time.Minute).Unix(),
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	request.Header.Set("Authorization", "Bearer "+token)
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("expected signed token allocation to return 201, got %d: %s", recorder.Code, recorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace unverified JWT payload extraction with RS256 verification through issuer discovery and JWKS caching
- enforce issuer, audience, subject, expiration, and not-before claims before authorizing broker requests
- add unit and handler-level regression coverage for forged, tampered, expired, and valid signed OIDC tokens
- document the accepted GitHub Actions OIDC policy

## Validation
- go test ./internal/api
- go test ./...

Closes #46