### PR TITLE
fix: remove unused cold reservation after warm allocation

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -300,6 +300,9 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 
 	if warmAllocation, ok := s.consumeWarmAllocation(ctx, pool, selected, allocation); ok {
 		s.schedulerForPool(pool).Release(pool.Name, selected, allocation)
+		if err := s.store.Delete(allocation.ID); err != nil {
+			return model.AllocationStatus{}, err
+		}
 		launchMode = launchModeWarm
 		warmAllocation.State = model.StateReady
 		warmAllocation.CorrelationID = allocation.CorrelationID

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1190,6 +1190,13 @@ func TestAllocatePrefersWarmAllocationOverColdLaunch(t *testing.T) {
 	if allocation.Metadata[backend.MetadataLaunchModeKey] != launchModeWarm {
 		t.Fatalf("expected warm launch mode, got %q", allocation.Metadata[backend.MetadataLaunchModeKey])
 	}
+	statuses := service.store.List()
+	if len(statuses) != 1 {
+		t.Fatalf("expected only consumed warm allocation to remain stored, got %+v", statuses)
+	}
+	if statuses[0].ID != allocation.ID || statuses[0].State != model.StateReady {
+		t.Fatalf("expected stored allocation to be consumed warm allocation, got %+v", statuses[0])
+	}
 
 	secondAllocation, err := service.Allocate(context.Background(), model.AllocationRequest{
 		Pool:       model.PoolLite,
@@ -1217,6 +1224,58 @@ func TestAllocatePrefersWarmAllocationOverColdLaunch(t *testing.T) {
 
 	if _, ok := service.Get(secondAllocation.ID); !ok {
 		t.Fatal("expected second allocation to be stored")
+	}
+}
+
+func TestFileStoreWarmConsumptionRehydratesOnlyRealAllocation(t *testing.T) {
+	statePath := t.TempDir() + "/allocations.json"
+	now := time.Unix(1000, 0)
+	cfg := config.Default()
+	cfg.Broker.StateStore = model.StateStoreConfig{Type: "file", Path: statePath}
+	for index := range cfg.Pools {
+		if cfg.Pools[index].Name != model.PoolLite {
+			continue
+		}
+		for name, backendCfg := range cfg.Pools[index].Backends {
+			backendCfg.Enabled = false
+			cfg.Pools[index].Backends[name] = backendCfg
+		}
+		codebuildCfg := cfg.Pools[index].Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 2
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		cfg.Pools[index].Backends[model.BackendCodeBuild] = codebuildCfg
+	}
+
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	first := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}, counting), nil)
+	first.now = func() time.Time { return now }
+	first.ReconcileWarmPools()
+
+	warmAllocation, err := first.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("warm allocation failed: %v", err)
+	}
+	if warmAllocation.Metadata[backend.MetadataLaunchModeKey] != launchModeWarm {
+		t.Fatalf("expected warm launch mode, got %q", warmAllocation.Metadata[backend.MetadataLaunchModeKey])
+	}
+
+	restarted := NewService(cfg, backend.NewRegistry(testBackend{name: model.BackendARC}, counting), nil)
+	restarted.now = func() time.Time { return now }
+	coldAllocation, err := restarted.Allocate(context.Background(), model.AllocationRequest{
+		Pool:       model.PoolLite,
+		JobTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("expected one remaining capacity slot after restart, got %v", err)
+	}
+	if coldAllocation.Metadata[backend.MetadataLaunchModeKey] != launchModeCold {
+		t.Fatalf("expected cold launch after warm was consumed, got %q", coldAllocation.Metadata[backend.MetadataLaunchModeKey])
 	}
 }
 

--- a/internal/store/file.go
+++ b/internal/store/file.go
@@ -58,6 +58,13 @@ func (f *File) Save(status model.AllocationStatus) error {
 	return f.persistLocked()
 }
 
+func (f *File) Delete(id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.allocations, id)
+	return f.persistLocked()
+}
+
 func (f *File) Get(id string) (model.AllocationStatus, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -9,6 +9,7 @@ import (
 
 type Store interface {
 	Save(model.AllocationStatus) error
+	Delete(string) error
 	Get(string) (model.AllocationStatus, bool)
 	List() []model.AllocationStatus
 	MarkState(string, model.AllocationState, time.Time, string) (model.AllocationStatus, bool)
@@ -27,6 +28,13 @@ func (m *Memory) Save(status model.AllocationStatus) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.allocations[status.ID] = status
+	return nil
+}
+
+func (m *Memory) Delete(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.allocations, id)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add a store delete operation for memory and file-backed allocation stores
- remove the unused cold placeholder after a warm allocation is consumed
- add regression coverage for in-memory store contents and file-store restart rehydration

## Validation
- go test ./internal/api
- go test ./...

Closes #47