### PR TITLE
feat: add desktop backend with TCP health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,60 @@ jobs:
           go test ./internal/api ./internal/config ./internal/runtime \
             -run "Test.*Tier" \
             -count=1
+
+  action-queue-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start mock broker
+        run: |
+          cat <<'EOF' > mock-broker.py
+          from http.server import HTTPServer, BaseHTTPRequestHandler
+          
+          class MockBroker(BaseHTTPRequestHandler):
+              call_count = 0
+              def do_POST(self):
+                  self.send_response(202)
+                  self.send_header("Content-Type", "application/json")
+                  self.end_headers()
+                  self.wfile.write(b'{"state": "pending", "allocation_id": "alloc-123", "retry_after": "2024-01-01T00:00:00Z"}')
+
+              def do_GET(self):
+                  MockBroker.call_count += 1
+                  if MockBroker.call_count < 2:
+                      self.send_response(202)
+                      self.send_header("Content-Type", "application/json")
+                      self.end_headers()
+                      self.wfile.write(b'{"state": "pending", "allocation_id": "alloc-123", "retry_after": "2024-01-01T00:00:00Z"}')
+                  else:
+                      self.send_response(200)
+                      self.send_header("Content-Type", "application/json")
+                      self.end_headers()
+                      self.wfile.write(b'{"state": "ready", "allocation_id": "alloc-123", "runner_label": "lbl-456", "selected_backend": "arc", "expires_at": "2025"}')
+          
+          HTTPServer(("127.0.0.1", 8080), MockBroker).serve_forever()
+          EOF
+          python3 mock-broker.py &
+          # Give it a second to start
+          sleep 1
+
+      - name: Test allocate-runner action
+        id: allocate
+        uses: ./actions/allocate-runner
+        with:
+          broker_url: http://127.0.0.1:8080
+          pool: test-pool
+          allow_unauthenticated: "true"
+
+      - name: Verify outputs
+        run: |
+          if [ "${{ steps.allocate.outputs.allocation_id }}" != "alloc-123" ]; then
+            echo "Expected alloc-123, got ${{ steps.allocate.outputs.allocation_id }}"
+            exit 1
+          fi
+          if [ "${{ steps.allocate.outputs.runner_label }}" != "lbl-456" ]; then
+            echo "Expected lbl-456, got ${{ steps.allocate.outputs.runner_label }}"
+            exit 1
+          fi
+

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -96,59 +96,59 @@ runs:
         fi
 
         request_body="$(python - <<'PY'
-import json
-import os
+        import json
+        import os
 
-payload = {
-    "pool": os.environ["INPUT_POOL"],
-    "job_timeout": os.environ["INPUT_JOB_TIMEOUT"],
-}
+        payload = {
+            "pool": os.environ["INPUT_POOL"],
+            "job_timeout": os.environ["INPUT_JOB_TIMEOUT"],
+        }
 
-backend = os.environ.get("INPUT_BACKEND", "").strip()
-if backend:
-    payload["backend"] = backend
+        backend = os.environ.get("INPUT_BACKEND", "").strip()
+        if backend:
+            payload["backend"] = backend
 
-labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
-if labels:
-    payload["labels"] = labels
+        labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
+        if labels:
+            payload["labels"] = labels
 
-tenant = os.environ.get("INPUT_TENANT", "").strip()
-if tenant:
-    payload["tenant"] = tenant
+        tenant = os.environ.get("INPUT_TENANT", "").strip()
+        if tenant:
+            payload["tenant"] = tenant
 
-priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
-if priority_class:
-    payload["priority_class"] = priority_class
+        priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
+        if priority_class:
+            payload["priority_class"] = priority_class
 
-required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
-if required_capabilities:
-    payload["required_capabilities"] = required_capabilities
+        required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
+        if required_capabilities:
+            payload["required_capabilities"] = required_capabilities
 
-excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
-if excluded_capabilities:
-    payload["excluded_capabilities"] = excluded_capabilities
+        excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
+        if excluded_capabilities:
+            payload["excluded_capabilities"] = excluded_capabilities
 
-print(json.dumps(payload))
-PY
-)"
+        print(json.dumps(payload))
+        PY
+        )"
 
         response="$(curl -fsSL "${auth_args[@]}" -H "Content-Type: application/json" -d "${request_body}" "${INPUT_BROKER_URL%/}/v1/allocations")"
 
         deadline="$(python - <<'PY'
-import os
-import re
-import time
+        import os
+        import re
+        import time
 
-value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
-match = re.fullmatch(r"(\d+)([smh]?)", value)
-if not match:
-    raise SystemExit(f"invalid queue_wait_timeout {value!r}")
-amount = int(match.group(1))
-unit = match.group(2) or "s"
-multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
-print(int(time.time()) + amount * multiplier)
-PY
-)"
+        value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
+        match = re.fullmatch(r"(\d+)([smh]?)", value)
+        if not match:
+            raise SystemExit(f"invalid queue_wait_timeout {value!r}")
+        amount = int(match.group(1))
+        unit = match.group(2) or "s"
+        multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
+        print(int(time.time()) + amount * multiplier)
+        PY
+        )"
 
         while [ "$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin).get('state',''))")" = "pending" ]; do
           now="$(date +%s)"
@@ -159,21 +159,21 @@ PY
           fi
           allocation_id="$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['allocation_id'])")"
           retry_after="$(export RESPONSE_JSON="${response}"; python - <<'PY'
-import datetime
-import json
-import os
+          import datetime
+          import json
+          import os
 
-payload = json.loads(os.environ["RESPONSE_JSON"])
-value = payload.get("retry_after")
-if not value:
-    print(5)
-    raise SystemExit
-dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
-now = datetime.datetime.now(datetime.timezone.utc)
-seconds = int((dt - now).total_seconds())
-print(max(1, min(seconds, 30)))
-PY
-)"
+          payload = json.loads(os.environ["RESPONSE_JSON"])
+          value = payload.get("retry_after")
+          if not value:
+              print(5)
+              raise SystemExit
+          dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+          now = datetime.datetime.now(datetime.timezone.utc)
+          seconds = int((dt - now).total_seconds())
+          print(max(1, min(seconds, 30)))
+          PY
+          )"
           sleep "${retry_after}"
           response="$(curl -fsSL "${auth_args[@]}" "${INPUT_BROKER_URL%/}/v1/allocations/${allocation_id}")"
         done

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -172,7 +172,7 @@ runs:
           now = datetime.datetime.now(datetime.timezone.utc)
           seconds = int((dt - now).total_seconds())
           print(max(1, min(seconds, 30)))
-          PY
+        PY
           )"
           sleep "${retry_after}"
           response="$(curl -fsSL "${auth_args[@]}" "${INPUT_BROKER_URL%/}/v1/allocations/${allocation_id}")"

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -96,59 +96,59 @@ runs:
         fi
 
         request_body="$(python - <<'PY'
-        import json
-        import os
+import json
+import os
 
-        payload = {
-            "pool": os.environ["INPUT_POOL"],
-            "job_timeout": os.environ["INPUT_JOB_TIMEOUT"],
-        }
+payload = {
+    "pool": os.environ["INPUT_POOL"],
+    "job_timeout": os.environ["INPUT_JOB_TIMEOUT"],
+}
 
-        backend = os.environ.get("INPUT_BACKEND", "").strip()
-        if backend:
-            payload["backend"] = backend
+backend = os.environ.get("INPUT_BACKEND", "").strip()
+if backend:
+    payload["backend"] = backend
 
-        labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
-        if labels:
-            payload["labels"] = labels
+labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
+if labels:
+    payload["labels"] = labels
 
-        tenant = os.environ.get("INPUT_TENANT", "").strip()
-        if tenant:
-            payload["tenant"] = tenant
+tenant = os.environ.get("INPUT_TENANT", "").strip()
+if tenant:
+    payload["tenant"] = tenant
 
-        priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
-        if priority_class:
-            payload["priority_class"] = priority_class
+priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
+if priority_class:
+    payload["priority_class"] = priority_class
 
-        required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
-        if required_capabilities:
-            payload["required_capabilities"] = required_capabilities
+required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
+if required_capabilities:
+    payload["required_capabilities"] = required_capabilities
 
-        excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
-        if excluded_capabilities:
-            payload["excluded_capabilities"] = excluded_capabilities
+excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
+if excluded_capabilities:
+    payload["excluded_capabilities"] = excluded_capabilities
 
-        print(json.dumps(payload))
-        PY
-        )"
+print(json.dumps(payload))
+PY
+)"
 
         response="$(curl -fsSL "${auth_args[@]}" -H "Content-Type: application/json" -d "${request_body}" "${INPUT_BROKER_URL%/}/v1/allocations")"
 
         deadline="$(python - <<'PY'
-        import os
-        import re
-        import time
+import os
+import re
+import time
 
-        value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
-        match = re.fullmatch(r"(\d+)([smh]?)", value)
-        if not match:
-            raise SystemExit(f"invalid queue_wait_timeout {value!r}")
-        amount = int(match.group(1))
-        unit = match.group(2) or "s"
-        multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
-        print(int(time.time()) + amount * multiplier)
-        PY
-        )"
+value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
+match = re.fullmatch(r"(\d+)([smh]?)", value)
+if not match:
+    raise SystemExit(f"invalid queue_wait_timeout {value!r}")
+amount = int(match.group(1))
+unit = match.group(2) or "s"
+multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
+print(int(time.time()) + amount * multiplier)
+PY
+)"
 
         while [ "$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin).get('state',''))")" = "pending" ]; do
           now="$(date +%s)"
@@ -159,21 +159,21 @@ runs:
           fi
           allocation_id="$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['allocation_id'])")"
           retry_after="$(export RESPONSE_JSON="${response}"; python - <<'PY'
-          import datetime
-          import json
-          import os
+import datetime
+import json
+import os
 
-          payload = json.loads(os.environ["RESPONSE_JSON"])
-          value = payload.get("retry_after")
-          if not value:
-              print(5)
-              raise SystemExit
-          dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
-          now = datetime.datetime.now(datetime.timezone.utc)
-          seconds = int((dt - now).total_seconds())
-          print(max(1, min(seconds, 30)))
-        PY
-          )"
+payload = json.loads(os.environ["RESPONSE_JSON"])
+value = payload.get("retry_after")
+if not value:
+    print(5)
+    raise SystemExit
+dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+now = datetime.datetime.now(datetime.timezone.utc)
+seconds = int((dt - now).total_seconds())
+print(max(1, min(seconds, 30)))
+PY
+)"
           sleep "${retry_after}"
           response="$(curl -fsSL "${auth_args[@]}" "${INPUT_BROKER_URL%/}/v1/allocations/${allocation_id}")"
         done

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -96,59 +96,59 @@ runs:
         fi
 
         request_body="$(python - <<'PY'
-import json
-import os
+        import json
+        import os
 
-payload = {
-    "pool": os.environ["INPUT_POOL"],
-    "job_timeout": os.environ["INPUT_JOB_TIMEOUT"],
-}
+        payload = {
+            "pool": os.environ["INPUT_POOL"],
+            "job_timeout": os.environ["INPUT_JOB_TIMEOUT"],
+        }
 
-backend = os.environ.get("INPUT_BACKEND", "").strip()
-if backend:
-    payload["backend"] = backend
+        backend = os.environ.get("INPUT_BACKEND", "").strip()
+        if backend:
+            payload["backend"] = backend
 
-labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
-if labels:
-    payload["labels"] = labels
+        labels = [item.strip() for item in os.environ.get("INPUT_LABELS", "").split(",") if item.strip()]
+        if labels:
+            payload["labels"] = labels
 
-tenant = os.environ.get("INPUT_TENANT", "").strip()
-if tenant:
-    payload["tenant"] = tenant
+        tenant = os.environ.get("INPUT_TENANT", "").strip()
+        if tenant:
+            payload["tenant"] = tenant
 
-priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
-if priority_class:
-    payload["priority_class"] = priority_class
+        priority_class = os.environ.get("INPUT_PRIORITY_CLASS", "").strip()
+        if priority_class:
+            payload["priority_class"] = priority_class
 
-required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
-if required_capabilities:
-    payload["required_capabilities"] = required_capabilities
+        required_capabilities = [item.strip() for item in os.environ.get("INPUT_REQUIRED_CAPABILITIES", "").split(",") if item.strip()]
+        if required_capabilities:
+            payload["required_capabilities"] = required_capabilities
 
-excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
-if excluded_capabilities:
-    payload["excluded_capabilities"] = excluded_capabilities
+        excluded_capabilities = [item.strip() for item in os.environ.get("INPUT_EXCLUDED_CAPABILITIES", "").split(",") if item.strip()]
+        if excluded_capabilities:
+            payload["excluded_capabilities"] = excluded_capabilities
 
-print(json.dumps(payload))
-PY
-)"
+        print(json.dumps(payload))
+        PY
+        )"
 
         response="$(curl -fsSL "${auth_args[@]}" -H "Content-Type: application/json" -d "${request_body}" "${INPUT_BROKER_URL%/}/v1/allocations")"
 
         deadline="$(python - <<'PY'
-import os
-import re
-import time
+        import os
+        import re
+        import time
 
-value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
-match = re.fullmatch(r"(\d+)([smh]?)", value)
-if not match:
-    raise SystemExit(f"invalid queue_wait_timeout {value!r}")
-amount = int(match.group(1))
-unit = match.group(2) or "s"
-multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
-print(int(time.time()) + amount * multiplier)
-PY
-)"
+        value = os.environ.get("INPUT_QUEUE_WAIT_TIMEOUT", "5m").strip()
+        match = re.fullmatch(r"(\d+)([smh]?)", value)
+        if not match:
+            raise SystemExit(f"invalid queue_wait_timeout {value!r}")
+        amount = int(match.group(1))
+        unit = match.group(2) or "s"
+        multiplier = {"s": 1, "m": 60, "h": 3600}[unit]
+        print(int(time.time()) + amount * multiplier)
+        PY
+        )"
 
         while [ "$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin).get('state',''))")" = "pending" ]; do
           now="$(date +%s)"
@@ -159,21 +159,21 @@ PY
           fi
           allocation_id="$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['allocation_id'])")"
           retry_after="$(export RESPONSE_JSON="${response}"; python - <<'PY'
-import datetime
-import json
-import os
+        import datetime
+        import json
+        import os
 
-payload = json.loads(os.environ["RESPONSE_JSON"])
-value = payload.get("retry_after")
-if not value:
-    print(5)
-    raise SystemExit
-dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
-now = datetime.datetime.now(datetime.timezone.utc)
-seconds = int((dt - now).total_seconds())
-print(max(1, min(seconds, 30)))
-PY
-)"
+        payload = json.loads(os.environ["RESPONSE_JSON"])
+        value = payload.get("retry_after")
+        if not value:
+            print(5)
+            raise SystemExit
+        dt = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        now = datetime.datetime.now(datetime.timezone.utc)
+        seconds = int((dt - now).total_seconds())
+        print(max(1, min(seconds, 30)))
+        PY
+          )"
           sleep "${retry_after}"
           response="$(curl -fsSL "${auth_args[@]}" "${INPUT_BROKER_URL%/}/v1/allocations/${allocation_id}")"
         done

--- a/actions/allocate-runner/action.yml
+++ b/actions/allocate-runner/action.yml
@@ -158,12 +158,12 @@ PY
             exit 1
           fi
           allocation_id="$(printf '%s' "${response}" | python -c "import json,sys; print(json.load(sys.stdin)['allocation_id'])")"
-          retry_after="$(printf '%s' "${response}" | python - <<'PY'
+          retry_after="$(export RESPONSE_JSON="${response}"; python - <<'PY'
 import datetime
 import json
-import sys
+import os
 
-payload = json.load(sys.stdin)
+payload = json.loads(os.environ["RESPONSE_JSON"])
 value = payload.get("retry_after")
 if not value:
     print(5)

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -14,6 +14,7 @@ import (
 	azurevmbackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/azurevm"
 	cloudbackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/cloudrun"
 	codebuildbackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/codebuild"
+	desktopbackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/desktop"
 	ec2backend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/ec2"
 	gcebackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/gce"
 	lambdabackend "github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend/lambda"
@@ -40,6 +41,7 @@ func main() {
 		cloudbackend.New(cfg, secretReader),
 		azurebackend.New(cfg, secretReader),
 		azurevmbackend.New(cfg),
+		desktopbackend.New(cfg),
 		ec2backend.New(cfg, secretReader),
 		gcebackend.New(cfg, secretReader),
 	)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,6 +12,30 @@ import (
 
 const MetadataCapabilitiesKey = "capabilities"
 const MetadataLaunchModeKey = "launch_mode"
+
+var ErrBackendCapacityExhausted = errors.New("backend capacity exhausted")
+
+type AllocationError struct {
+	Err               error
+	Reason            error
+	CapacityExhausted bool
+}
+
+func (e *AllocationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *AllocationError) Unwrap() error {
+	return e.Err
+}
+
+func NewAllocationError(err error, reason error, capacityExhausted bool) error {
+	return &AllocationError{
+		Err:               err,
+		Reason:            reason,
+		CapacityExhausted: capacityExhausted,
+	}
+}
 
 type ProvisionedRunner struct {
 	RunnerLabel string

--- a/internal/backend/desktop/backend.go
+++ b/internal/backend/desktop/backend.go
@@ -1,0 +1,71 @@
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/backend"
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
+)
+
+type Backend struct {
+	cfg model.BrokerConfig
+}
+
+func New(cfg model.BrokerConfig) *Backend {
+	return &Backend{cfg: cfg}
+}
+
+func (b *Backend) Name() model.BackendName {
+	return model.BackendDesktop
+}
+
+func (b *Backend) Provision(_ context.Context, request model.AllocationRequest, allocation model.AllocationStatus) (backend.ProvisionedRunner, error) {
+	cfg, _ := b.backendConfig(allocation.Pool)
+
+	if cfg.Desktop != nil && cfg.Desktop.Address != "" && cfg.Desktop.CheckPort > 0 {
+		address := fmt.Sprintf("%s:%d", cfg.Desktop.Address, cfg.Desktop.CheckPort)
+		conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+		if err != nil {
+			return backend.ProvisionedRunner{}, backend.NewAllocationError(fmt.Errorf("desktop is offline"), backend.ErrBackendCapacityExhausted, true)
+		}
+		conn.Close()
+	}
+
+	runnerLabel := b.runnerLabel(allocation.Pool, allocation.ID)
+	return backend.ProvisionedRunner{
+		RunnerLabel: runnerLabel,
+		Metadata: map[string]string{
+			"pool":         string(request.Pool),
+			"provisioner":  "desktop",
+			"runner_label": runnerLabel,
+		},
+	}, nil
+}
+
+func (b *Backend) runnerLabel(poolName model.PoolName, allocationID string) string {
+	if cfg, ok := b.backendConfig(poolName); ok {
+		if runnerLabel := strings.TrimSpace(cfg.RunnerLabel); runnerLabel != "" {
+			return runnerLabel
+		}
+		if template := strings.TrimSpace(cfg.Template); template != "" {
+			return template
+		}
+	}
+
+	return backend.DefaultRunnerLabel(model.BackendDesktop, allocationID)
+}
+
+func (b *Backend) backendConfig(poolName model.PoolName) (model.BackendConfig, bool) {
+	for _, pool := range b.cfg.Pools {
+		if pool.Name != poolName {
+			continue
+		}
+		cfg, ok := pool.Backends[model.BackendDesktop]
+		return cfg, ok
+	}
+	return model.BackendConfig{}, false
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -13,6 +13,7 @@ const (
 	BackendAzureVM        BackendName = "azure-vm"
 	BackendEC2            BackendName = "ec2"
 	BackendGCE            BackendName = "gce"
+	BackendDesktop        BackendName = "desktop"
 )
 
 type PoolName string
@@ -147,6 +148,11 @@ type RateLimitConfig struct {
 	Burst    int           `yaml:"burst,omitempty" json:"burst,omitempty"`
 }
 
+type DesktopConfig struct {
+	Address   string `yaml:"address" json:"address"`
+	CheckPort int    `yaml:"checkPort" json:"checkPort"`
+}
+
 type BackendConfig struct {
 	Enabled        bool                 `yaml:"enabled" json:"enabled"`
 	Healthy        bool                 `yaml:"healthy" json:"healthy"`
@@ -163,6 +169,7 @@ type BackendConfig struct {
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuitBreaker,omitempty" json:"circuitBreaker,omitempty"`
 	RateLimit      RateLimitConfig      `yaml:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 	TierRules      []TierRuleConfig     `yaml:"tierRules,omitempty" json:"tierRules,omitempty"`
+	Desktop        *DesktopConfig       `yaml:"desktop,omitempty" json:"desktop,omitempty"`
 }
 
 type TierRuleConfig struct {

--- a/scripts/install-desktop-runner.ps1
+++ b/scripts/install-desktop-runner.ps1
@@ -1,0 +1,41 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$RepoUrl,
+    
+    [Parameter(Mandatory=$true)]
+    [string]$Token,
+
+    [string]$RunnerName = $env:COMPUTERNAME,
+    [string]$InstallDir = "C:\actions-runner"
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Create installation directory
+Write-Host "Creating installation directory at $InstallDir..."
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+}
+Set-Location $InstallDir
+
+# Download Runner
+Write-Host "Downloading GitHub Actions Runner..."
+Invoke-WebRequest -Uri "https://github.com/actions/runner/releases/download/v2.317.0/actions-runner-win-x64-2.317.0.zip" -OutFile "runner.zip"
+
+# Extract Runner
+Write-Host "Extracting Runner..."
+Expand-Archive "runner.zip" -DestinationPath . -Force
+Remove-Item "runner.zip"
+
+# Configure Runner
+Write-Host "Configuring Runner with UECB desktop labels..."
+.\config.cmd --unattended --url $RepoUrl --token $Token --name $RunnerName --labels "desktop-runner,windows,desktop" --replace
+
+# Setup Auto-Recovery on Boot (Startup Folder)
+Write-Host "Setting up auto-recovery (Startup folder)..."
+$startupFolder = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup"
+$vbsPath = "$startupFolder\GitHubActionsRunner.vbs"
+$vbsContent = "Set WshShell = CreateObject(`"WScript.Shell`")`r`nWshShell.Run `"$InstallDir\run.cmd`", 0, False"
+Set-Content -Path $vbsPath -Value $vbsContent
+
+Write-Host "Installation Complete! To start it right now, run: Start-Process -FilePath `"$InstallDir\run.cmd`" -WindowStyle Hidden" -ForegroundColor Green

--- a/scripts/install-desktop-runner.sh
+++ b/scripts/install-desktop-runner.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${1:-}"
+TOKEN="${2:-}"
+RUNNER_NAME="${3:-$(hostname)}"
+INSTALL_DIR="${4:-/opt/actions-runner}"
+
+if [ -z "$REPO_URL" ] || [ -z "$TOKEN" ]; then
+  echo "Usage: $0 <REPO_URL> <TOKEN> [RUNNER_NAME] [INSTALL_DIR]"
+  exit 1
+fi
+
+echo "Creating installation directory at $INSTALL_DIR..."
+sudo mkdir -p "$INSTALL_DIR"
+sudo chown "$USER:$USER" "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+echo "Downloading GitHub Actions Runner..."
+curl -o actions-runner-linux-x64-2.317.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.317.0/actions-runner-linux-x64-2.317.0.tar.gz
+
+echo "Extracting Runner..."
+tar xzf ./actions-runner-linux-x64-2.317.0.tar.gz
+rm ./actions-runner-linux-x64-2.317.0.tar.gz
+
+echo "Configuring Runner with UECB desktop labels..."
+./config.sh --unattended --url "$REPO_URL" --token "$TOKEN" --name "$RUNNER_NAME" --labels "desktop-runner,linux,desktop" --replace
+
+echo "Setting up auto-recovery (systemd service)..."
+sudo ./svc.sh install
+sudo ./svc.sh start
+
+echo "Installation Complete! Runner is running as a systemd service."


### PR DESCRIPTION
This adds a desktop backend that pings an address/port via TCP to verify the host is online before allocating a runner. If the dial times out, it throws a capacity exhausted error to allow fallback or queueing.