### PR TITLE
Render every GitOps pack variant in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           helm template uecb charts/unified-ephemeral-runner-broker >/tmp/uecb-helm.yaml
           kubectl kustomize examples/gitops/kustomize/base >/tmp/uecb-kustomize.yaml
 
+      - name: Render GitOps pack variants
+        run: ./scripts/validate-gitops-packs.sh
+
   api-docs-contract:
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +44,6 @@ jobs:
 
       - name: API docs and action contract check
         run: bash scripts/check-api-docs-contract.sh
-
   warm-pool-regression:
     runs-on: ubuntu-latest
     steps:

--- a/examples/gitops/packs/README.md
+++ b/examples/gitops/packs/README.md
@@ -58,6 +58,19 @@ Pin to a tag or commit SHA. Never consume a floating `main` reference in product
 └── feature-flags.md        # staged rollout, backend enable/disable, pinning, rollback
 ```
 
+## Validate Pack Renders
+
+Before submitting pack changes, render every published base and overlay from the
+repository root:
+
+```bash
+./scripts/validate-gitops-packs.sh
+```
+
+The command requires Bash 4 or later and `kubectl` with built-in Kustomize
+support. It discovers every `kustomization.yaml` below this directory, so new
+packs and overlays are included automatically.
+
 ## Safe Offload Pattern
 
 External automation in these packs does not use native GitHub Actions `schedule:` triggers for infrastructure operations. Periodic tasks such as capacity health checks or warm-pool status reports are offloaded to a Kubernetes CronJob running in the same cluster as the broker.

--- a/scripts/validate-gitops-packs.sh
+++ b/scripts/validate-gitops-packs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+packs_root="${repo_root}/examples/gitops/packs"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "ERROR: kubectl is required to render the GitOps packs." >&2
+  exit 1
+fi
+
+mapfile -t targets < <(
+  find "${packs_root}" -type f -name kustomization.yaml -print |
+    LC_ALL=C sort
+)
+
+if ((${#targets[@]} == 0)); then
+  echo "ERROR: no GitOps pack Kustomizations found under ${packs_root}." >&2
+  exit 1
+fi
+
+rendered_output="$(mktemp)"
+trap 'rm -f "${rendered_output}"' EXIT
+
+status=0
+for kustomization in "${targets[@]}"; do
+  target="$(dirname "${kustomization}")"
+  relative_target="${target#"${repo_root}/"}"
+
+  echo "Rendering ${relative_target}"
+  if ! kubectl kustomize "${target}" >"${rendered_output}"; then
+    echo "ERROR: failed to render ${relative_target}" >&2
+    status=1
+  fi
+done
+
+if ((status != 0)); then
+  exit "${status}"
+fi
+
+echo "Successfully rendered ${#targets[@]} GitOps pack targets."


### PR DESCRIPTION
## Summary

- add a reusable discovery-based validator for every published GitOps pack Kustomization
- run the validator in CI after the existing manifest sanity checks
- document the local validation command and prerequisites for contributors

## Impact

All nine current base, staging, and production targets are rendered on pull requests and main. Newly added packs or overlays are discovered automatically, and failures name the exact target path.

## Validation

- `git diff --check origin/main...HEAD`
- `bash ./scripts/validate-gitops-packs.sh` (all 9 current targets rendered)
- `go test ./...`
- negative discovery check with a temporary malformed tenth overlay (auto-discovered, failed, and named its path)

Closes #53