### PR TITLE
Keep allocation endpoint documentation synchronized

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,20 +129,52 @@ sequenceDiagram
 Machine-readable reference: [docs/openapi.yaml](docs/openapi.yaml)
 (`POST`/`GET` `/v1/allocations`, complete, cancel; OIDC auth and correlation headers).
 
-### Completion Callback Endpoint
+All allocation endpoints require a GitHub OIDC bearer token unless
+`allowUnauthenticated` is enabled.
 
-The broker accepts completion callbacks on:
+| Operation | Method and path | Success response |
+| --- | --- | --- |
+| Create | `POST /v1/allocations` | `201 Created` when a runner is ready, or `202 Accepted` with a `Retry-After` header when queued |
+| Status | `GET /v1/allocations/{id}` | `200 OK` with the current allocation |
+| Cancel | `POST /v1/allocations/{id}/cancel` | `200 OK` with the canceled allocation |
+| Complete | `POST /v1/allocations/{id}/complete` | `200 OK` with the terminal allocation |
 
-`POST /v1/allocations/{id}/complete`
+Create requests include a pool and job timeout:
 
-Supported payload forms:
+```json
+{
+  "pool": "full",
+  "job_timeout": "15m"
+}
+```
+
+Every successful operation returns the allocation status. A ready allocation
+has this core response shape:
+
+```json
+{
+  "allocation_id": "alloc-123",
+  "correlation_id": "request-123",
+  "pool": "full",
+  "selected_backend": "arc",
+  "runner_label": "uecb-alloc-123",
+  "expires_at": "2026-07-17T12:00:00Z",
+  "state": "ready"
+}
+```
+
+Queued allocations use `state: pending`, may omit the runner label until they
+are ready, and include `retry_after` in the response body.
+
+Completion callbacks accept these payload forms:
 
 - `{ "state": "completed" }` (default state)
 - `{ "state": "completed" | "failed" | "canceled", "reason": "...", "error": "..." }`
 - `{ "state": "expired" }`
 - `{ "state": "quarantined" }`
 
-Duplicate callbacks for the same terminal state are idempotent and do not re-release scheduler capacity.
+Duplicate callbacks for the same terminal state are idempotent and do not
+re-release scheduler capacity.
 
 ### Orphan cleanup and quarantine
 

--- a/examples/gitops/packs/arc-only/validation.md
+++ b/examples/gitops/packs/arc-only/validation.md
@@ -33,13 +33,18 @@ If you have a test workflow that calls `allocate-runner`, trigger it against the
 Alternatively, use `curl` with a valid OIDC token:
 
 ```bash
-curl -s -X POST http://localhost:8080/v1/allocations \
+curl -sS -o /tmp/uecb-allocation.json -w 'HTTP %{http_code}\n' \
+  -X POST http://localhost:8080/v1/allocations \
   -H "Authorization: Bearer <OIDC_TOKEN>" \
   -H "Content-Type: application/json" \
-  -d '{"pool":"full","job_timeout":"5m"}' | jq .
+  -d '{"pool":"full","job_timeout":"5m"}'
+jq . /tmp/uecb-allocation.json
 ```
 
-Expected: response contains `runner_label` and `correlation_id`.
+Expected: `HTTP 201` and a response with `state: "ready"`, `allocation_id`,
+`runner_label`, and `correlation_id`. When queued admission is enabled, the
+broker can instead return `HTTP 202` with `state: "pending"` and `retry_after`;
+poll `GET /v1/allocations/{id}` until the allocation becomes ready.
 
 ## 5. Confirm ARC Backends Are Healthy
 

--- a/internal/api/docs_contract_test.go
+++ b/internal/api/docs_contract_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var obsoleteAllocationRoutePattern = regexp.MustCompile(`/(?:v1/)?allocate\b`)
+
+func TestPublicAllocationDocsUseRegisteredRoutes(t *testing.T) {
+	root := documentationRepositoryRoot(t)
+	readme, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+
+	for _, route := range []string{
+		"POST /v1/allocations",
+		"GET /v1/allocations/{id}",
+		"POST /v1/allocations/{id}/cancel",
+		"POST /v1/allocations/{id}/complete",
+	} {
+		if !strings.Contains(string(readme), route) {
+			t.Errorf("README.md does not document registered route %q", route)
+		}
+	}
+
+	for _, path := range publicDocumentationFiles(t, root) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		if match := findObsoleteAllocationRoute(content); match != nil {
+			relativePath, relativeErr := filepath.Rel(root, path)
+			if relativeErr != nil {
+				relativePath = path
+			}
+			t.Errorf("%s contains obsolete allocation route %q", relativePath, match)
+		}
+	}
+}
+
+func TestObsoleteAllocationRoutePattern(t *testing.T) {
+	for input, wantMatch := range map[string]bool{
+		"POST /allocate":                  true,
+		"POST http://broker/v1/allocate":  true,
+		"POST /v1/allocate?pool=full":     true,
+		"POST /v1/allocations":            false,
+		"GET /v1/allocations/alloc-123":   false,
+		"uses: ./actions/allocate-runner": false,
+	} {
+		if got := findObsoleteAllocationRoute([]byte(input)) != nil; got != wantMatch {
+			t.Errorf("obsolete route match for %q = %t, want %t", input, got, wantMatch)
+		}
+	}
+}
+
+func findObsoleteAllocationRoute(content []byte) []byte {
+	for _, location := range obsoleteAllocationRoutePattern.FindAllIndex(content, -1) {
+		if bytes.HasPrefix(content[location[1]:], []byte("-runner")) {
+			continue
+		}
+		return content[location[0]:location[1]]
+	}
+	return nil
+}
+
+func documentationRepositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve docs contract test path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func publicDocumentationFiles(t *testing.T, root string) []string {
+	t.Helper()
+	paths := []string{filepath.Join(root, "README.md")}
+	for _, directory := range []string{"docs", "examples"} {
+		err := filepath.WalkDir(filepath.Join(root, directory), func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			switch strings.ToLower(filepath.Ext(path)) {
+			case ".json", ".md", ".sh", ".yaml", ".yml":
+				paths = append(paths, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("scan public documentation in %s: %v", directory, err)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
## Summary

- replace obsolete singular allocation endpoint examples with `/v1/allocations`
- document the registered create, status, cancel, and completion routes with their successful status and response shapes
- add a Go documentation-contract test that rejects obsolete `/allocate` and `/v1/allocate` literals in public docs and examples

## Impact

Operators can copy the documented arc-only validation command without receiving a route-level 404, and CI prevents the stale endpoint literals from returning. No broker behavior or compatibility alias is added.

## Validation

- `git diff --check origin/main...HEAD`
- `go test ./...`
- `go vet ./...`

Closes #54