### PR TITLE
fix: prevent warm pool double-consume race (#60)

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -722,7 +722,19 @@ func (s *Service) consumeWarmAllocation(ctx context.Context, pool model.PoolConf
 			s.recycleWarmAllocation(ctx, pool, candidate, "warm allocation expired")
 			continue
 		}
-		return candidate, true
+		// Claim under warmMu before returning so concurrent consumers cannot
+		// observe the same StateWarm runner. filterWarmAllocations only returns
+		// StateWarm, so MarkState→ready removes it from the warm set atomically
+		// with respect to other consumeWarmAllocation callers.
+		current, ok := s.store.Get(candidate.ID)
+		if !ok || current.State != model.StateWarm {
+			continue
+		}
+		claimed, ok := s.store.MarkState(candidate.ID, model.StateReady, now, "")
+		if !ok || claimed.State != model.StateReady {
+			continue
+		}
+		return claimed, true
 	}
 
 	return model.AllocationStatus{}, false

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1224,6 +1225,100 @@ func TestAllocatePrefersWarmAllocationOverColdLaunch(t *testing.T) {
 
 	if _, ok := service.Get(secondAllocation.ID); !ok {
 		t.Fatal("expected second allocation to be stored")
+	}
+}
+
+func TestConcurrentAllocateDoesNotDoubleConsumeWarm(t *testing.T) {
+	now := time.Unix(1000, 0)
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	service := newServiceWithCountingBackend(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 2
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	}, counting)
+	service.now = func() time.Time { return now }
+
+	service.ReconcileWarmPools()
+	warmBefore := filterWarmAllocations(service.store.List(), model.PoolLite, model.BackendCodeBuild)
+	if len(warmBefore) != 1 {
+		t.Fatalf("expected one warm allocation before concurrent allocate, got %d", len(warmBefore))
+	}
+	warmID := warmBefore[0].ID
+
+	const workers = 2
+	start := make(chan struct{})
+	type result struct {
+		status model.AllocationStatus
+		err    error
+	}
+	results := make([]result, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			status, err := service.Allocate(context.Background(), model.AllocationRequest{
+				Pool:       model.PoolLite,
+				JobTimeout: 5 * time.Minute,
+				// Distinct tenants so fair-share / correlation paths stay independent.
+				Tenant: fmt.Sprintf("tenant-%d", i),
+			})
+			results[i] = result{status: status, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	ids := make(map[string]struct{}, workers)
+	labels := make(map[string]struct{}, workers)
+	var warmHits int
+	for i, res := range results {
+		if res.err != nil {
+			t.Fatalf("worker %d allocate failed: %v", i, res.err)
+		}
+		if res.status.ID == "" {
+			t.Fatalf("worker %d returned empty allocation id", i)
+		}
+		if _, dup := ids[res.status.ID]; dup {
+			t.Fatalf("duplicate allocation id %q handed to two jobs", res.status.ID)
+		}
+		ids[res.status.ID] = struct{}{}
+		if res.status.RunnerLabel != "" {
+			if _, dup := labels[res.status.RunnerLabel]; dup {
+				t.Fatalf("duplicate runner label %q handed to two jobs", res.status.RunnerLabel)
+			}
+			labels[res.status.RunnerLabel] = struct{}{}
+		}
+		if res.status.Metadata[backend.MetadataLaunchModeKey] == launchModeWarm {
+			warmHits++
+			if res.status.ID != warmID {
+				t.Fatalf("warm launch used unexpected id %q, want %q", res.status.ID, warmID)
+			}
+		}
+	}
+	if warmHits != 1 {
+		t.Fatalf("expected exactly one warm consumption, got %d (results=%+v)", warmHits, results)
+	}
+	if len(ids) != workers {
+		t.Fatalf("expected %d unique allocation ids, got %d", workers, len(ids))
+	}
+
+	// The pre-warmed runner must not still be StateWarm after exclusive claim.
+	if remaining := filterWarmAllocations(service.store.List(), model.PoolLite, model.BackendCodeBuild); len(remaining) != 0 {
+		t.Fatalf("expected no residual warm allocations, got %+v", remaining)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `consumeWarmAllocation` now **claims** a warm runner under `warmMu` by verifying `StateWarm` and `MarkState` → `StateReady` before returning, so concurrent allocators cannot both observe the same warm ID.
- A second concurrent consumer falls through to cold launch when the warm candidate is already claimed.
- Single-threaded warm preference behavior is unchanged; `allocateNow` still applies correlation/tenant/labels/expiry metadata after the claim.

## Test plan
- [x] `go test ./internal/api/ -count=1`
- [x] `go test ./internal/api/ -count=1 -run 'Warm|ConcurrentAllocate'`
- [ ] `go test -race` for the new test (not run: host lacks CGO/gcc for race builds)
- New regression: `TestConcurrentAllocateDoesNotDoubleConsumeWarm` — two goroutines allocate against one warm runner; asserts unique allocation IDs/labels and exactly one warm launch mode.

Closes #60