### PR TITLE
feat: external-dispatch Cleanup for cancel/expire teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,10 @@ See [docs/architecture.md](docs/architecture.md) and [docs/security-boundary.md]
 2. Create the GitHub auth secret and any enabled backend secrets in the same namespace as the broker.
    The broker validates referenced `secretRef` objects via the Kubernetes API and stays unready until they exist.
    External backend secrets should provide:
-   `dispatch_url`: the controller endpoint the broker should call.
+   `dispatch_url`: the controller endpoint the broker should call for provision.
    `health_url`: health endpoint used by circuit-breaker recovery probes when the backend enables `circuitBreaker`.
-   `dispatch_token`: optional bearer token sent to that endpoint.
+   `dispatch_token`: optional bearer token sent to dispatch, health, and cleanup endpoints.
+   `cleanup_url` (optional): controller endpoint the broker POSTs on cancel/expire/release so the provider can tear down runners. When omitted, cleanup is skipped (capacity is still released); when set, launchers should treat cleanup as idempotent (2xx and 404 both OK).
 3. Point the `allocate-runner` action at the broker URL. The broker accepts `job_timeout` in the same duration-string format used by the action, for example `15m`.
 4. Start with the `full` pool or ARC-only `lite` pool. Only enable an external backend after you have supplied a real launcher integration for that platform and the matching `secretRef`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@
   document and JWKS before authorizing allocation or completion requests.
 - The broker selects a backend, reserves capacity, provisions a runner, and returns the label that the heavy job should target.
 - External backends read `dispatch_url` and optional `dispatch_token` from their configured `secretRef` and hand off provisioning to a provider-owned controller.
+- On cancel, expire, quarantine terminal, or warm recycle, the broker calls `CleanupBackend.Cleanup` when implemented. Shared external-dispatch backends POST to optional secret key `cleanup_url` with `action: "cleanup"`, allocation id, runner label, state, and provision metadata (for example `execution_id`). Auth reuses `dispatch_token` as a Bearer token. Missing `cleanup_url` is a soft no-op so capacity release still succeeds; launchers should treat cleanup as idempotent (HTTP 2xx and 404 are success).
 - Provider-owned controllers can use the public `pkg/adapter` SDK and `pkg/adapter/adaptertest` conformance harness to keep health, capacity, reserve, launch, and cleanup behavior aligned with the broker contract.
 
 ## Data Plane

--- a/examples/gitops/packs/arc-plus-codebuild/secrets.md
+++ b/examples/gitops/packs/arc-plus-codebuild/secrets.md
@@ -22,13 +22,17 @@ The broker uses this secret to dispatch runner allocation requests to your CodeB
 kubectl create secret generic uecb-codebuild \
   --namespace arc-systems \
   --from-literal=dispatch_url=https://<YOUR_CODEBUILD_DISPATCHER_ENDPOINT> \
+  --from-literal=cleanup_url=https://<YOUR_CODEBUILD_DISPATCHER_ENDPOINT>/cleanup \
   --from-literal=dispatch_token=<BEARER_TOKEN_FOR_DISPATCHER>
 ```
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `dispatch_url` | HTTPS URL | The HTTP endpoint of your CodeBuild launcher controller that accepts broker dispatch requests |
-| `dispatch_token` | string | Optional bearer token sent in the `Authorization` header to the dispatcher; leave blank if your dispatcher uses a network boundary instead of a token |
+| `cleanup_url` | HTTPS URL | Optional. Endpoint the broker POSTs on cancel/expire/release so the launcher can tear down the runner. Omit to skip provider teardown (broker capacity still releases). Prefer idempotent handlers (2xx and 404 both OK). |
+| `dispatch_token` | string | Optional bearer token sent in the `Authorization` header to the dispatcher (and cleanup when set); leave blank if your dispatcher uses a network boundary instead of a token |
+
+Cleanup POST body includes `action: "cleanup"`, `allocation_id`, `runner_label`, `backend`, `pool`, `state`, optional `correlation_id` / `error`, and allocation `metadata` (for example `execution_id` from provision).
 
 The dispatcher endpoint is operated by your private CodeBuild launcher controller (not part of this repository). See `docs/architecture.md` for the external dispatch contract.
 

--- a/examples/gitops/packs/multi-backend/secrets.md
+++ b/examples/gitops/packs/multi-backend/secrets.md
@@ -18,12 +18,14 @@ The broker uses this secret to dispatch allocation requests to your AWS Lambda l
 kubectl create secret generic uecb-lambda \
   --namespace arc-systems \
   --from-literal=dispatch_url=https://<YOUR_LAMBDA_DISPATCHER_ENDPOINT> \
+  --from-literal=cleanup_url=https://<YOUR_LAMBDA_DISPATCHER_ENDPOINT>/cleanup \
   --from-literal=dispatch_token=<BEARER_TOKEN_FOR_DISPATCHER>
 ```
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `dispatch_url` | HTTPS URL | The HTTP endpoint of your Lambda launcher controller |
+| `cleanup_url` | HTTPS URL | Optional. POST target for cancel/expire teardown; omit to skip provider cleanup |
 | `dispatch_token` | string | Optional bearer token; leave blank if the endpoint uses a network boundary instead |
 
 The Lambda launcher is a private controller that wraps the `lambda` OCI image published from this repository. The Lambda function image must be mirrored into ECR because AWS Lambda requires the function image to reside in a registry in the same account. The broker only calls the dispatcher endpoint; it does not interact with ECR or Lambda directly.
@@ -36,12 +38,14 @@ The broker uses this secret to dispatch allocation requests to your GCP Cloud Ru
 kubectl create secret generic uecb-cloud-run \
   --namespace arc-systems \
   --from-literal=dispatch_url=https://<YOUR_CLOUD_RUN_DISPATCHER_ENDPOINT> \
+  --from-literal=cleanup_url=https://<YOUR_CLOUD_RUN_DISPATCHER_ENDPOINT>/cleanup \
   --from-literal=dispatch_token=<BEARER_TOKEN_FOR_DISPATCHER>
 ```
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `dispatch_url` | HTTPS URL | The HTTP endpoint of your Cloud Run launcher controller |
+| `cleanup_url` | HTTPS URL | Optional. POST target for cancel/expire teardown; omit to skip provider cleanup |
 | `dispatch_token` | string | Optional bearer token |
 
 ## Secret Provisioning Order

--- a/internal/backend/externaldispatch/backend.go
+++ b/internal/backend/externaldispatch/backend.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -19,6 +20,7 @@ import (
 
 const (
 	secretKeyDispatchURL          = "dispatch_url"
+	secretKeyCleanupURL           = "cleanup_url"
 	secretKeyHealthURL            = "health_url"
 	secretKeyDispatchToken        = "dispatch_token"
 	defaultDispatchTimeout        = 20 * time.Second
@@ -66,6 +68,20 @@ type dispatchResponse struct {
 	StatusURL   string            `json:"status_url"`
 	DetailsURL  string            `json:"details_url"`
 	ExecutionID string            `json:"execution_id"`
+}
+
+// cleanupRequest is the JSON body POSTed to cleanup_url (or derived cleanup endpoint).
+// Launchers should treat cleanup as idempotent: 200/204 and 404 are success.
+type cleanupRequest struct {
+	Action         string            `json:"action"`
+	Backend        string            `json:"backend"`
+	AllocationID   string            `json:"allocation_id"`
+	CorrelationID  string            `json:"correlation_id,omitempty"`
+	Pool           string            `json:"pool"`
+	RunnerLabel    string            `json:"runner_label"`
+	State          string            `json:"state"`
+	Error          string            `json:"error,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
 }
 
 func New(name model.BackendName, cfg model.BrokerConfig, secrets runtime.SecretReader) *Backend {
@@ -269,6 +285,107 @@ func (b *Backend) Probe(ctx context.Context, pool model.PoolConfig, cfg model.Ba
 		return backend.NewClassifiedError(reason, err)
 	}
 	return err
+}
+
+// Cleanup tears down provider-side runners for a terminal allocation.
+//
+// Contract:
+//   - Optional secret key cleanup_url. When set, the broker POSTs a cleanup JSON
+//     body to that URL with the same Bearer dispatch_token used for dispatch.
+//   - When cleanup_url is absent, Cleanup logs and returns nil so capacity release
+//     still succeeds (launchers that do not implement teardown remain compatible).
+//   - Idempotent responses: HTTP 2xx and 404 are treated as success.
+func (b *Backend) Cleanup(ctx context.Context, status model.AllocationStatus) error {
+	pool, err := resolvePool(b.cfg, status.Pool)
+	if err != nil {
+		// Soft-skip: release capacity even if pool config has been removed.
+		log.Printf("externaldispatch cleanup skipped for allocation %s backend %s: %v", status.ID, b.name, err)
+		return nil
+	}
+
+	backendCfg, ok := pool.Backends[b.name]
+	if !ok {
+		log.Printf("externaldispatch cleanup skipped for allocation %s: backend %s not configured for pool %s", status.ID, b.name, pool.Name)
+		return nil
+	}
+	secretRef := strings.TrimSpace(backendCfg.SecretRef)
+	if secretRef == "" {
+		log.Printf("externaldispatch cleanup skipped for allocation %s backend %s: missing secretRef", status.ID, b.name)
+		return nil
+	}
+
+	secretData, err := b.secrets.ReadSecret(ctx, secretRef)
+	if err != nil {
+		return fmt.Errorf("read backend secret %s: %w", secretRef, err)
+	}
+
+	cleanupURL := strings.TrimSpace(secretData[secretKeyCleanupURL])
+	if cleanupURL == "" {
+		log.Printf("externaldispatch cleanup skipped for allocation %s backend %s: secret %s has no %q", status.ID, b.name, secretRef, secretKeyCleanupURL)
+		return nil
+	}
+
+	dispatchToken := strings.TrimSpace(secretData[secretKeyDispatchToken])
+	runnerLabel := strings.TrimSpace(status.RunnerLabel)
+	if runnerLabel == "" {
+		runnerLabel = backend.DefaultRunnerLabel(b.name, status.ID)
+	}
+
+	payload := cleanupRequest{
+		Action:        "cleanup",
+		Backend:       string(b.name),
+		AllocationID:  status.ID,
+		CorrelationID: strings.TrimSpace(status.CorrelationID),
+		Pool:          string(status.Pool),
+		RunnerLabel:   runnerLabel,
+		State:         string(status.State),
+		Error:         strings.TrimSpace(status.Error),
+		Metadata:      cloneMetadata(status.Metadata),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cleanupURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-UECB-Backend", string(b.name))
+	if dispatchToken != "" {
+		req.Header.Set("Authorization", "Bearer "+dispatchToken)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return classifyDispatchError(b.name, err)
+	}
+	defer resp.Body.Close()
+
+	// Idempotent cleanup: success and not-found are both OK.
+	if (resp.StatusCode >= 200 && resp.StatusCode < 300) || resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+
+	message, readErr := readErrorMessage(resp.Body)
+	baseErr := fmt.Errorf("cleanup backend %s: unexpected status %d", b.name, resp.StatusCode)
+	if readErr != nil || message == "" {
+		return baseErr
+	}
+	return fmt.Errorf("cleanup backend %s: %s", b.name, message)
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		result[key] = value
+	}
+	return result
 }
 
 func classifyDispatchError(name model.BackendName, err error) error {

--- a/internal/backend/externaldispatch/backend_test.go
+++ b/internal/backend/externaldispatch/backend_test.go
@@ -402,6 +402,178 @@ func TestProbeRequiresSuccessfulHealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestCleanupPostsToCleanupURL(t *testing.T) {
+	var gotMethod string
+	var gotAuth string
+	var gotBackendHeader string
+	var payload cleanupRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotBackendHeader = r.Header.Get("X-UECB-Backend")
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode cleanup request: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := newRepoScopedConfig()
+	dispatchBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyDispatchURL:   "https://dispatch.example.invalid",
+			secretKeyCleanupURL:    server.URL,
+			secretKeyDispatchToken: "broker-secret",
+		},
+	})
+
+	err := dispatchBackend.Cleanup(context.Background(), model.AllocationStatus{
+		ID:              "alloc-1",
+		CorrelationID:   "corr-9",
+		Pool:            model.PoolLite,
+		SelectedBackend: model.BackendCodeBuild,
+		RunnerLabel:     "uecb-codebuild-alloc-1",
+		State:           model.StateCanceled,
+		Error:           "client canceled",
+		Metadata: map[string]string{
+			"execution_id": "run-123",
+			"provider":     "codebuild",
+		},
+	})
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", gotMethod)
+	}
+	if gotAuth != "Bearer broker-secret" {
+		t.Fatalf("expected bearer auth, got %q", gotAuth)
+	}
+	if gotBackendHeader != string(model.BackendCodeBuild) {
+		t.Fatalf("expected backend header %q, got %q", model.BackendCodeBuild, gotBackendHeader)
+	}
+	if payload.Action != "cleanup" {
+		t.Fatalf("expected action cleanup, got %q", payload.Action)
+	}
+	if payload.AllocationID != "alloc-1" {
+		t.Fatalf("expected allocation id alloc-1, got %q", payload.AllocationID)
+	}
+	if payload.CorrelationID != "corr-9" {
+		t.Fatalf("expected correlation id corr-9, got %q", payload.CorrelationID)
+	}
+	if payload.RunnerLabel != "uecb-codebuild-alloc-1" {
+		t.Fatalf("unexpected runner label %q", payload.RunnerLabel)
+	}
+	if payload.Backend != string(model.BackendCodeBuild) {
+		t.Fatalf("unexpected backend %q", payload.Backend)
+	}
+	if payload.State != string(model.StateCanceled) {
+		t.Fatalf("unexpected state %q", payload.State)
+	}
+	if payload.Metadata["execution_id"] != "run-123" {
+		t.Fatalf("expected execution_id metadata, got %+v", payload.Metadata)
+	}
+}
+
+func TestCleanupTreatsNotFoundAsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"already gone"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := newRepoScopedConfig()
+	dispatchBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyDispatchURL: "https://dispatch.example.invalid",
+			secretKeyCleanupURL:  server.URL,
+		},
+	})
+
+	err := dispatchBackend.Cleanup(context.Background(), model.AllocationStatus{
+		ID:   "alloc-gone",
+		Pool: model.PoolLite,
+		State: model.StateExpired,
+	})
+	if err != nil {
+		t.Fatalf("expected 404 cleanup to succeed, got %v", err)
+	}
+}
+
+func TestCleanupSurfacesRemoteFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"cleanup rejected"}`, http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	cfg := newRepoScopedConfig()
+	dispatchBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyDispatchURL: "https://dispatch.example.invalid",
+			secretKeyCleanupURL:  server.URL,
+		},
+	})
+
+	err := dispatchBackend.Cleanup(context.Background(), model.AllocationStatus{
+		ID:   "alloc-fail",
+		Pool: model.PoolLite,
+		State: model.StateCanceled,
+	})
+	if err == nil || !strings.Contains(err.Error(), "cleanup rejected") {
+		t.Fatalf("expected remote cleanup error, got %v", err)
+	}
+}
+
+func TestCleanupMissingCleanupURLIsNoop(t *testing.T) {
+	cfg := newRepoScopedConfig()
+	dispatchBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyDispatchURL:   "https://dispatch.example.invalid",
+			secretKeyDispatchToken: "broker-secret",
+		},
+	})
+
+	err := dispatchBackend.Cleanup(context.Background(), model.AllocationStatus{
+		ID:   "alloc-skip",
+		Pool: model.PoolLite,
+		State: model.StateCanceled,
+	})
+	if err != nil {
+		t.Fatalf("expected missing cleanup_url to be a no-op, got %v", err)
+	}
+}
+
+func TestCleanupDefaultsRunnerLabelWhenEmpty(t *testing.T) {
+	var payload cleanupRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode cleanup request: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cfg := newRepoScopedConfig()
+	dispatchBackend := New(model.BackendCodeBuild, cfg, staticSecrets{
+		"uecb-codebuild": {
+			secretKeyCleanupURL: server.URL,
+		},
+	})
+
+	err := dispatchBackend.Cleanup(context.Background(), model.AllocationStatus{
+		ID:   "xyz",
+		Pool: model.PoolLite,
+		State: model.StateExpired,
+	})
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+	if payload.RunnerLabel != "uecb-codebuild-xyz" {
+		t.Fatalf("expected default runner label, got %q", payload.RunnerLabel)
+	}
+}
+
 func contains(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {


### PR DESCRIPTION
## Summary
- Implement `CleanupBackend.Cleanup` on `internal/backend/externaldispatch` so cancel/expire/warm recycle tear down provider runners, not only broker capacity.
- **Contract:** optional secret key `cleanup_url`. Broker POSTs JSON (`action: cleanup`, allocation id, runner label, backend, pool, state, correlation id, error, metadata) with Bearer `dispatch_token` when set. Missing `cleanup_url` logs and returns nil (capacity release still works). HTTP 2xx and 404 are success (idempotent).
- Docs: README, architecture, pack secrets (`arc-plus-codebuild`, `multi-backend`).

## Tests
- `go test ./internal/backend/... ./internal/api/ -count=1`
- Unit coverage: cleanup success + auth/payload, 404 OK, remote failure, missing `cleanup_url` no-op, default runner label.

Closes #63