### PR TITLE
Publish OpenAPI for allocation API and CI-check action/pack contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
           helm template uecb charts/unified-ephemeral-runner-broker >/tmp/uecb-helm.yaml
           kubectl kustomize examples/gitops/kustomize/base >/tmp/uecb-kustomize.yaml
 
+  api-docs-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: API docs and action contract check
+        run: bash scripts/check-api-docs-contract.sh
+
   warm-pool-regression:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sequenceDiagram
     participant R as Ephemeral Runner
 
     GH->>AR: Run action
-    AR->>B: POST /allocate (OIDC Token)
+    AR->>B: POST /v1/allocations (OIDC Token)
     B->>B: Validate OIDC & Auth
     B->>B: Capability Filtering
     B->>B: Scheduler Selection
@@ -123,6 +123,11 @@ sequenceDiagram
 4. `job_timeout` is accepted as duration strings like `15m`, with numeric nanoseconds still accepted for backward compatibility.
 5. The heavy workflow job runs on that exact label.
 6. The runner executes one job and exits.
+
+### Allocation API
+
+Machine-readable reference: [docs/openapi.yaml](docs/openapi.yaml)
+(`POST`/`GET` `/v1/allocations`, complete, cancel; OIDC auth and correlation headers).
 
 ### Completion Callback Endpoint
 
@@ -198,7 +203,7 @@ the allocation until it becomes `ready` or `queue_wait_timeout` expires.
 - `charts/unified-ephemeral-runner-broker`: Helm chart
 - `actions/allocate-runner`: public workflow integration surface
 - `examples/`: generic Terraform and GitOps consumption examples
-- `docs/`: architecture and security notes
+- `docs/`: architecture notes, security boundary, and [OpenAPI](docs/openapi.yaml) for the allocation API
 - `observability/`: reusable Prometheus alert rules and Grafana dashboard artifacts
 - `pkg/adapter`: public backend adapter SDK and conformance test helpers
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,384 @@
+openapi: 3.0.3
+info:
+  title: Unified Ephemeral Runner Broker Allocation API
+  description: |
+    Public HTTP surface for allocating one-shot GitHub Actions runners.
+
+    When `broker.allowUnauthenticated` is false (default for production), every
+    allocation route requires a GitHub Actions OIDC bearer token.
+
+    Clients may send `X-Correlation-ID`; the broker always echoes it on the
+    response (generating a value when the request omits one).
+  version: 1.0.0
+
+servers:
+  - url: /
+    description: Broker base URL (for example https://broker.example.com)
+
+tags:
+  - name: allocations
+    description: Allocate, poll, complete, and cancel runner capacity
+
+paths:
+  /v1/allocations:
+    post:
+      tags: [allocations]
+      operationId: createAllocation
+      summary: Create an allocation
+      description: |
+        Requests a runner from the given pool. On success returns `201 Created`
+        with `state: ready` (or another non-pending state). When admission
+        queueing is enabled and the request is queued, returns `202 Accepted`
+        with `state: pending` and a `Retry-After` header (seconds).
+      security:
+        - bearerOIDC: []
+      parameters:
+        - $ref: '#/components/parameters/CorrelationID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AllocationRequest'
+            examples:
+              basic:
+                value:
+                  pool: full
+                  job_timeout: 15m
+              pinned:
+                value:
+                  pool: lite
+                  backend: codebuild
+                  job_timeout: 5m
+                  tenant: team-a
+                  priority_class: high
+      responses:
+        '201':
+          description: Allocation admitted and ready (or otherwise non-pending)
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/CorrelationID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationStatus'
+        '202':
+          description: Allocation queued; poll GET until ready or timeout
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/CorrelationID'
+            Retry-After:
+              description: Suggested seconds before polling again
+              schema:
+                type: string
+                example: "30"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationStatus'
+        '400':
+          $ref: '#/components/responses/Error'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '405':
+          $ref: '#/components/responses/Error'
+
+  /v1/allocations/{id}:
+    get:
+      tags: [allocations]
+      operationId: getAllocation
+      summary: Get allocation status
+      security:
+        - bearerOIDC: []
+      parameters:
+        - $ref: '#/components/parameters/AllocationID'
+        - $ref: '#/components/parameters/CorrelationID'
+      responses:
+        '200':
+          description: Current allocation status
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/CorrelationID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/Error'
+        '405':
+          $ref: '#/components/responses/Error'
+
+  /v1/allocations/{id}/complete:
+    post:
+      tags: [allocations]
+      operationId: completeAllocation
+      summary: Complete an allocation
+      description: |
+        Marks an allocation terminal. Duplicate callbacks for the same terminal
+        state are idempotent. `failure_class` on failed completions can trip
+        backend circuit breakers (for example `wait-timeout`).
+      security:
+        - bearerOIDC: []
+      parameters:
+        - $ref: '#/components/parameters/AllocationID'
+        - $ref: '#/components/parameters/CorrelationID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompletionRequest'
+            examples:
+              completed:
+                value:
+                  state: completed
+              failed:
+                value:
+                  state: failed
+                  error: runner crashed
+                  failure_class: wait-timeout
+      responses:
+        '200':
+          description: Updated allocation status
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/CorrelationID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationStatus'
+        '400':
+          $ref: '#/components/responses/Error'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/Error'
+        '405':
+          $ref: '#/components/responses/Error'
+
+  /v1/allocations/{id}/cancel:
+    post:
+      tags: [allocations]
+      operationId: cancelAllocation
+      summary: Cancel an allocation
+      description: Cancels a non-terminal allocation and releases reserved capacity when applicable.
+      security:
+        - bearerOIDC: []
+      parameters:
+        - $ref: '#/components/parameters/AllocationID'
+        - $ref: '#/components/parameters/CorrelationID'
+      responses:
+        '200':
+          description: Updated allocation status
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/CorrelationID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocationStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/Error'
+        '405':
+          $ref: '#/components/responses/Error'
+
+components:
+  securitySchemes:
+    bearerOIDC:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        GitHub Actions OIDC ID token (`Authorization: Bearer <token>`).
+        Required unless the broker is configured with `allowUnauthenticated: true`.
+        Typical claims: `iss=https://token.actions.githubusercontent.com`,
+        `aud` matching `broker.api.oidcAudience` (default `uecb-broker`).
+
+  parameters:
+    AllocationID:
+      name: id
+      in: path
+      required: true
+      description: Allocation identifier returned as `allocation_id`
+      schema:
+        type: string
+    CorrelationID:
+      name: X-Correlation-ID
+      in: header
+      required: false
+      description: Optional client correlation ID; echoed on the response
+      schema:
+        type: string
+
+  headers:
+    CorrelationID:
+      description: Correlation ID for this request (echoed or generated)
+      schema:
+        type: string
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid bearer token
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/CorrelationID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Error:
+      description: Request error
+      headers:
+        X-Correlation-ID:
+          $ref: '#/components/headers/CorrelationID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    AllocationRequest:
+      type: object
+      required:
+        - pool
+        - job_timeout
+      properties:
+        pool:
+          type: string
+          description: Target capacity pool (for example full or lite)
+          example: full
+        backend:
+          type: string
+          description: Optional pin to a specific backend name
+          example: arc
+        job_timeout:
+          description: |
+            Requested job duration. Prefer Go duration strings such as `15m`.
+            Numeric nanosecond integers are still accepted for compatibility.
+          oneOf:
+            - type: string
+              example: 15m
+            - type: integer
+              format: int64
+              description: Nanoseconds
+        tenant:
+          type: string
+          description: Optional tenant or queue identity for fair-share scheduling
+        priority_class:
+          type: string
+          description: Optional priority class (for example normal or high)
+          example: high
+        labels:
+          type: array
+          items:
+            type: string
+          description: Optional labels attached to the allocation request
+        required_capabilities:
+          type: array
+          items:
+            type: string
+          description: Capability tags the selected backend must advertise
+        excluded_capabilities:
+          type: array
+          items:
+            type: string
+          description: Capability tags the selected backend must not advertise
+
+    AllocationStatus:
+      type: object
+      required:
+        - allocation_id
+        - pool
+        - selected_backend
+        - runner_label
+        - expires_at
+        - state
+      properties:
+        allocation_id:
+          type: string
+        correlation_id:
+          type: string
+        pool:
+          type: string
+        selected_backend:
+          type: string
+          example: arc
+        runner_label:
+          type: string
+        requested_labels:
+          type: array
+          items:
+            type: string
+        tenant:
+          type: string
+        priority_class:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+        retry_after:
+          type: string
+          format: date-time
+          description: Present when state is pending (queue admission)
+        attempts:
+          type: integer
+        state:
+          $ref: '#/components/schemas/AllocationState'
+        error:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        request:
+          $ref: '#/components/schemas/AllocationRequest'
+
+    CompletionRequest:
+      type: object
+      properties:
+        state:
+          type: string
+          description: |
+            Terminal state. Empty defaults to completed.
+            Accepted aliases include complete/completed/success/succeeded,
+            failed/failure/error, canceled/cancelled/cancel, expired,
+            quarantined/quarantine.
+          example: completed
+        reason:
+          type: string
+          description: Human-readable reason (used for non-failed terminals)
+        error:
+          type: string
+          description: Error message when state is failed
+        failure_class:
+          type: string
+          description: |
+            Optional failure classification for circuit-breaker accounting
+            (for example wait-timeout).
+          example: wait-timeout
+
+    AllocationState:
+      type: string
+      enum:
+        - reserved
+        - ready
+        - warm
+        - pending
+        - canceled
+        - expired
+        - failed
+        - completed
+        - quarantined
+
+    Error:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          example: allocation not found

--- a/examples/gitops/packs/arc-only/feature-flags.md
+++ b/examples/gitops/packs/arc-only/feature-flags.md
@@ -63,14 +63,14 @@ pools:
 
 ## Backend Pinning
 
-Clients can request a specific backend by including `pin_backend` in the allocation request. This overrides scheduler selection for that request.
+Clients can request a specific backend by including `backend` in the allocation request (action input and JSON field). This overrides scheduler selection for that request.
 
 ```yaml
 - uses: ./actions/allocate-runner
   with:
     broker_url: https://broker.example.com
     pool: lite
-    pin_backend: arc
+    backend: arc
 ```
 
 Pinned requests still honor capability filters and the `enabled`/`healthy` flags. If the pinned backend is disabled or unhealthy, the broker returns a clear rejection.

--- a/examples/gitops/packs/arc-only/validation.md
+++ b/examples/gitops/packs/arc-only/validation.md
@@ -33,7 +33,7 @@ If you have a test workflow that calls `allocate-runner`, trigger it against the
 Alternatively, use `curl` with a valid OIDC token:
 
 ```bash
-curl -s -X POST http://localhost:8080/v1/allocate \
+curl -s -X POST http://localhost:8080/v1/allocations \
   -H "Authorization: Bearer <OIDC_TOKEN>" \
   -H "Content-Type: application/json" \
   -d '{"pool":"full","job_timeout":"5m"}' | jq .

--- a/examples/gitops/packs/arc-plus-codebuild/feature-flags.md
+++ b/examples/gitops/packs/arc-plus-codebuild/feature-flags.md
@@ -101,7 +101,7 @@ Pin an allocation to a specific backend:
   with:
     broker_url: https://broker.example.com
     pool: lite
-    pin_backend: codebuild
+    backend: codebuild
 ```
 
 Useful for testing CodeBuild capacity specifically, or routing specific job types to a known backend. Pinned requests still honor the `enabled` and `healthy` flags.

--- a/examples/gitops/packs/multi-backend/feature-flags.md
+++ b/examples/gitops/packs/multi-backend/feature-flags.md
@@ -121,7 +121,7 @@ Pin an allocation to a specific backend, overriding scheduler selection:
   with:
     broker_url: https://broker.example.com
     pool: lite
-    pin_backend: lambda
+    backend: lambda
 ```
 
 Pinned requests still honor the `enabled` and `healthy` flags, and capability filters apply. If the pinned backend is disabled or its capabilities do not match, the broker returns a clear rejection.

--- a/scripts/check-api-docs-contract.sh
+++ b/scripts/check-api-docs-contract.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Fails when public docs/examples drift from the live allocation API and
+# allocate-runner action contracts (see issue #64 / #54).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+status=0
+
+# Paths scanned for obsolete public-facing literals (not Go sources/tests).
+DOC_PATHS=(
+  README.md
+  docs
+  examples
+  actions
+)
+
+# Action-only inputs that never appear on the allocation request body.
+ACTION_ONLY_INPUTS=(
+  broker_url
+  oidc_audience
+  allow_unauthenticated
+  queue_wait_timeout
+)
+
+fail() {
+  echo "error: $*" >&2
+  status=1
+}
+
+info() {
+  echo "$*"
+}
+
+# --- 1. Obsolete path: /v1/allocate (must be /v1/allocations) ---------------
+# Match /v1/allocate not followed by 's' so /v1/allocations is allowed.
+info "Checking for obsolete /v1/allocate path in public docs/examples..."
+obsolete_path_hits="$(
+  { git grep -nE '/v1/allocate([^s/]|$|/)' -- "${DOC_PATHS[@]}" 2>/dev/null || true; } \
+    | { grep -v 'scripts/check-api-docs-contract.sh' || true; }
+)"
+if [[ -n "${obsolete_path_hits}" ]]; then
+  echo "${obsolete_path_hits}" >&2
+  fail "found obsolete create path /v1/allocate; use /v1/allocations"
+else
+  info "  ok: no /v1/allocate create-path literals"
+fi
+
+# --- 2. Obsolete action input: pin_backend (correct: backend) ---------------
+info "Checking for obsolete pin_backend input in public docs/examples..."
+pin_hits="$(
+  { git grep -n 'pin_backend' -- "${DOC_PATHS[@]}" 2>/dev/null || true; } \
+    | { grep -v 'scripts/check-api-docs-contract.sh' || true; }
+)"
+if [[ -n "${pin_hits}" ]]; then
+  echo "${pin_hits}" >&2
+  fail "found obsolete pin_backend; use action/API field backend"
+else
+  info "  ok: no pin_backend literals"
+fi
+
+# --- 3. OpenAPI artifact present --------------------------------------------
+OPENAPI="docs/openapi.yaml"
+if [[ ! -f "${OPENAPI}" ]]; then
+  fail "missing ${OPENAPI}"
+else
+  info "  ok: ${OPENAPI} present"
+fi
+
+# --- 4. Action inputs ⊆ OpenAPI AllocationRequest properties + action-only --
+ACTION_YML="actions/allocate-runner/action.yml"
+if [[ -f "${ACTION_YML}" && -f "${OPENAPI}" ]]; then
+  info "Checking allocate-runner inputs against OpenAPI AllocationRequest..."
+
+  mapfile -t action_inputs < <(
+    # Under inputs:, collect top-level keys (two-space indent, name then colon).
+    awk '
+      /^inputs:[[:space:]]*$/ { in_inputs=1; next }
+      in_inputs && /^[^[:space:]#]/ { exit }
+      in_inputs && /^  [a-zA-Z0-9_]+:/ {
+        line=$0
+        sub(/^  /, "", line)
+        sub(/:.*/, "", line)
+        print line
+      }
+    ' "${ACTION_YML}"
+  )
+
+  mapfile -t openapi_props < <(
+    awk '
+      /^    AllocationRequest:[[:space:]]*$/ { in_schema=1; next }
+      in_schema && /^    [A-Za-z]/ { exit }
+      in_schema && /^      properties:[[:space:]]*$/ { in_props=1; next }
+      in_props && /^        [a-zA-Z0-9_]+:/ {
+        line=$0
+        sub(/^        /, "", line)
+        sub(/:.*/, "", line)
+        print line
+      }
+      # Leave properties block at the next 6-space key under the schema
+      # (for example required already passed; siblings would be rare).
+      in_props && /^      [a-zA-Z0-9_]+:/ { exit }
+    ' "${OPENAPI}"
+  )
+
+  is_action_only() {
+    local name="$1"
+    local only
+    for only in "${ACTION_ONLY_INPUTS[@]}"; do
+      if [[ "${name}" == "${only}" ]]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  is_openapi_prop() {
+    local name="$1"
+    local prop
+    for prop in "${openapi_props[@]}"; do
+      if [[ "${name}" == "${prop}" ]]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  if [[ ${#action_inputs[@]} -eq 0 ]]; then
+    fail "could not parse inputs from ${ACTION_YML}"
+  elif [[ ${#openapi_props[@]} -eq 0 ]]; then
+    fail "could not parse AllocationRequest properties from ${OPENAPI}"
+  else
+    for input in "${action_inputs[@]}"; do
+      if is_action_only "${input}"; then
+        continue
+      fi
+      if ! is_openapi_prop "${input}"; then
+        fail "action input '${input}' is not an AllocationRequest property in ${OPENAPI} and is not listed as action-only"
+      fi
+    done
+    if [[ "${status}" -eq 0 ]]; then
+      info "  ok: action body inputs match OpenAPI AllocationRequest properties"
+    fi
+  fi
+fi
+
+# --- 5. OpenAPI documents required allocation routes ------------------------
+if [[ -f "${OPENAPI}" ]]; then
+  info "Checking OpenAPI path coverage..."
+  required_paths=(
+    '/v1/allocations:'
+    '/v1/allocations/{id}:'
+    '/v1/allocations/{id}/complete:'
+    '/v1/allocations/{id}/cancel:'
+  )
+  for path_key in "${required_paths[@]}"; do
+    if ! grep -qF "  ${path_key}" "${OPENAPI}"; then
+      fail "OpenAPI missing path key: ${path_key}"
+    fi
+  done
+  if [[ "${status}" -eq 0 ]]; then
+    info "  ok: create/get/complete/cancel paths present"
+  fi
+fi
+
+if [[ "${status}" -ne 0 ]]; then
+  echo "API docs contract check failed." >&2
+  exit "${status}"
+fi
+
+echo "API docs contract check passed."


### PR DESCRIPTION
## Summary
- Add `docs/openapi.yaml` covering `POST/GET /v1/allocations`, complete, and cancel (OIDC auth, `X-Correlation-ID`, request/response fields, completion body including `failure_class`).
- Link OpenAPI from the README (allocation API + project layout).
- Add `scripts/check-api-docs-contract.sh` and a CI job that fails on obsolete `/v1/allocate` and `pin_backend` in public docs/examples, and checks `allocate-runner` body inputs against OpenAPI `AllocationRequest` properties.
- Fix pack docs that still used `pin_backend` or `/v1/allocate` (related to #54).

Closes #64

## Validation
- Ran `bash scripts/check-api-docs-contract.sh` (pass).
- Negative test: reintroducing `pin_backend` fails the check.
- No Go behavior changes.