### PR TITLE
feat: compose fair-share with weighted-round-robin (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,17 +481,35 @@ Use warm pools where external cold-start latency dominates.
 
 ### Priority And Fair-Share Scheduling
 
-Pools can opt into tenant-aware dispatch independently of the backend scheduler with `fairShare.enabled`.
+Pools can opt into tenant-aware dispatch with `fairShare.enabled`. Fair-share **composes** with the pool's backend scheduler (`round-robin` or `weighted-round-robin`):
+
+1. **Tenant admission** — enforce optional per-tenant `quotas`, track active usage by tenant and priority class.
+2. **Fair-share ranking** — prefer backends with lower active load and lower active usage for the requesting tenant; higher priority classes reduce the tenant penalty when capacity is available.
+3. **Backend pick** — among backends with equal fair-share scores and free capacity, select using the pool scheduler. With `weighted-round-robin`, backend `weight` values still shape selection; with `round-robin`, each eligible backend gets one slot.
+
+Recommended configuration (matches the multi-backend pack):
 
 ```yaml
 pools:
   - name: lite
-    scheduler: weighted-round-robin
+    scheduler: weighted-round-robin   # weights apply when fair-share scores tie
     fairShare:
       enabled: true
       priorityClasses:
         normal: 1
         high: 2
+      quotas:                         # optional hard caps on concurrent active allocations
+        noisy-team: 4
+        release: 20
+    backends:
+      arc:
+        enabled: true
+        maxRunners: 4
+        weight: 3
+      codebuild:
+        enabled: true
+        maxRunners: 4
+        weight: 2
 ```
 
 Allocation requests may include:
@@ -499,7 +517,19 @@ Allocation requests may include:
 - `tenant`: queue, team, or workflow owner used for fair-share accounting
 - `priority_class`: priority class such as `normal` or `high`
 
-When enabled, fair-share admission prefers eligible backends with lower active load and lower active usage for the requesting tenant. Higher priority classes reduce the tenant penalty for that request, so urgent work can dispatch sooner when capacity is available. It does not preempt active runners, and allocations without a tenant use the `default` tenant bucket.
+Fair-share does not preempt active runners. Allocations without a tenant use the `default` tenant bucket. Optional `fairShare.quotas` reject new reservations for a tenant once its concurrent active count reaches the configured limit (other tenants are unaffected).
+
+`usageWindow` and `starvationAfter` are reserved config keys and are not applied yet.
+
+#### Config surface (single path)
+
+| Knob | Role |
+|------|------|
+| `pools[].fairShare.enabled: true` | **Recommended** enable path for tenant/priority admission and ranking |
+| `pools[].scheduler: weighted-round-robin` / `round-robin` | Backend selection among equal fair-share scores (weights only for WRR) |
+| `pools[].scheduler: priority-fair-share` | Standalone fair-share backend pick (no weight expansion); same shared scheduler instance as `fairShare.enabled` |
+
+Prefer `fairShare.enabled` plus `weighted-round-robin` or `round-robin`. Setting `scheduler: priority-fair-share` alone is equivalent to fair-share ranking without WRR weight expansion.
 
 ```yaml
 - uses: ./actions/allocate-runner

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,9 +63,17 @@ when no backend can run the allocation.
 
 Within a selected pool, backends use `round-robin` across healthy backends with available slots.
 
-Pools can opt into `weighted-round-robin` instead. Backend weights are configured per pool and only affect selection when that scheduler is enabled.
+Pools can opt into `weighted-round-robin` instead. Backend weights are configured per pool and affect selection when that scheduler is enabled.
 
-Pools can also enable `fairShare` independently from the backend scheduler. Allocation requests may include `tenant` and `priority_class`; fair-share admission uses active allocation counts to prefer lower-loaded backends and avoid repeatedly favoring a tenant that already has active work. Priority only affects dispatch choice when capacity is available. The broker does not preempt active runners.
+Pools can also enable `fairShare`. Fair-share **composes** with the pool backend scheduler rather than replacing it:
+
+1. Optional per-tenant `fairShare.quotas` reject over-quota tenants before backend pick.
+2. Fair-share ranks eligible backends by active load and per-tenant usage; higher `priority_class` weights reduce the tenant penalty when capacity exists.
+3. Among backends with equal fair-share scores and free capacity, the pool scheduler chooses the backend. With `weighted-round-robin`, backend `weight` values still influence the pick; with `round-robin`, each backend has one slot.
+
+Allocation requests may include `tenant` and `priority_class`. Priority only affects dispatch choice when capacity is available. The broker does not preempt active runners. `usageWindow` and `starvationAfter` are reserved and unused today.
+
+Recommended path: `fairShare.enabled: true` with `scheduler: weighted-round-robin` or `round-robin`. `scheduler: priority-fair-share` is a standalone fair-share mode without weight expansion and shares the same fair-share state instance as `fairShare.enabled`.
 
 ## Runtime Backend Admission
 

--- a/examples/gitops/kustomize/README.md
+++ b/examples/gitops/kustomize/README.md
@@ -14,7 +14,7 @@ Create that Secret in your private overlay (or via ExternalSecret/secret manager
 
 ## Scheduler overlays
 
-The base keeps `round-robin` and `fairShare.enabled=false` as safe defaults. Private overlays can set `pools[].scheduler` to `weighted-round-robin`, enable `pools[].fairShare.enabled`, and tune `fairShare.priorityClasses` without changing live state by hand.
+The base keeps `round-robin` and `fairShare.enabled=false` as safe defaults. Private overlays can set `pools[].scheduler` to `weighted-round-robin`, enable `pools[].fairShare.enabled`, and tune `fairShare.priorityClasses` / `fairShare.quotas` without changing live state by hand. When both are enabled, fair-share ranks tenants then the pool scheduler (including WRR weights) picks among equal-score backends.
 
 ## Runtime admission overlays
 
@@ -26,4 +26,4 @@ For complete topology-specific examples with overlays, secret contract documenta
 
 - [`arc-only`](../packs/arc-only/README.md) — ARC-only, round-robin
 - [`arc-plus-codebuild`](../packs/arc-plus-codebuild/README.md) — hybrid ARC + CodeBuild, weighted-round-robin
-- [`multi-backend`](../packs/multi-backend/README.md) — ARC + CodeBuild + Lambda + Cloud Run, fair-share
+- [`multi-backend`](../packs/multi-backend/README.md) — ARC + CodeBuild + Lambda + Cloud Run, fair-share composed with WRR

--- a/examples/gitops/packs/multi-backend/README.md
+++ b/examples/gitops/packs/multi-backend/README.md
@@ -1,6 +1,6 @@
 # multi-backend Reference Pack
 
-This pack deploys the broker in a multi-backend hybrid topology with ARC as the in-cluster backend and AWS CodeBuild, AWS Lambda, and GCP Cloud Run as external backends. The lite pool uses `weighted-round-robin` scheduling with `fairShare` tenant scheduling enabled.
+This pack deploys the broker in a multi-backend hybrid topology with ARC as the in-cluster backend and AWS CodeBuild, AWS Lambda, and GCP Cloud Run as external backends. The lite pool enables **composed** scheduling: `fairShare` ranks by tenant/priority, then `weighted-round-robin` picks among equal-score backends so backend `weight` values still apply (arc 3, codebuild 2, lambda 1, cloud-run 1).
 
 ## When to Use
 
@@ -19,8 +19,8 @@ allocate-runner action (with optional tenant + priority_class)
         ▼
  ┌──────────────────────────┐
  │  Broker (arc-systems)    │
- │  Fair-share admission    │
- │  Weighted-round-robin    │
+ │  Fair-share → then WRR   │
+ │  (compose, weights apply)│
  └──────────────────────────┘
         │
    ┌────┼──────────────────┬─────────────────┐

--- a/examples/gitops/packs/multi-backend/feature-flags.md
+++ b/examples/gitops/packs/multi-backend/feature-flags.md
@@ -43,7 +43,12 @@ backends:
 
 ## Fair-Share Scheduling
 
-### Disable fair-share (fall back to pure weighted-round-robin)
+Fair-share **composes** with the pool scheduler. With this pack's default (`scheduler: weighted-round-robin` + `fairShare.enabled: true`):
+
+1. Tenant quotas and fair-share scores rank backends.
+2. When scores tie, backend `weight` values drive WRR selection.
+
+### Disable fair-share (pure weighted-round-robin only)
 
 ```yaml
 pools:
@@ -51,6 +56,8 @@ pools:
     fairShare:
       enabled: false
 ```
+
+Backend weights continue to apply via `weighted-round-robin`.
 
 ### Adjust priority class weights
 
@@ -69,6 +76,20 @@ pools:
 
 Allocation requests must include `priority_class: critical` to benefit from the higher weight.
 
+### Cap concurrent allocations per tenant
+
+```yaml
+pools:
+  - name: lite
+    fairShare:
+      enabled: true
+      quotas:
+        noisy-team: 2
+        release: 10
+```
+
+Once a tenant reaches its quota of active allocations, further reserves for that tenant fail with a quota error until capacity is released. Other tenants are unaffected.
+
 ### Send tenant and priority in a workflow
 
 ```yaml
@@ -84,7 +105,7 @@ Allocations without a `tenant` value use the `default` tenant bucket. The broker
 
 ## Scheduler Selection
 
-To fall back from `weighted-round-robin` to `round-robin` for a pool (ignoring backend weights):
+To fall back from `weighted-round-robin` to `round-robin` for a pool (ignoring backend weights, still composed with fair-share when enabled):
 
 ```yaml
 pools:
@@ -92,7 +113,7 @@ pools:
     scheduler: round-robin
 ```
 
-Weights are preserved and take effect again when `weighted-round-robin` is restored.
+Weights are preserved in config and take effect again when `weighted-round-robin` is restored. Prefer this dual-knob shape (`fairShare.enabled` + `scheduler`) over `scheduler: priority-fair-share`, which is standalone fair-share without weight expansion.
 
 ## Orphan Cleanup
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -57,10 +57,12 @@ func NewService(cfg model.BrokerConfig, registry *backend.Registry, health func(
 		stateStore = store.NewMemory()
 	}
 	service := &Service{
-		cfg:       cfg,
-		registry:  registry,
-		scheds:    schedulerRegistry,
-		fairShare: scheduler.NewPriorityFairShare(),
+		cfg:      cfg,
+		registry: registry,
+		scheds:   schedulerRegistry,
+		// Share one PriorityFairShare instance with the scheduler registry so
+		// fairShare.enabled and scheduler: priority-fair-share do not diverge.
+		fairShare: schedulerRegistry.PriorityFairShare(),
 		store:     stateStore,
 		observer:  noopObserver{},
 		admission: newBackendAdmission(),

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -617,6 +617,50 @@ func TestAllocateUsesPriorityFairShareScheduler(t *testing.T) {
 	}
 }
 
+func TestAllocateFairShareComposesWithWeightedRoundRobin(t *testing.T) {
+	service := newServiceWithConfig(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		pool.Scheduler = scheduler.NameWeightedRoundRobin
+		pool.FairShare.Enabled = true
+		// Keep only arc + codebuild so the weight ring is deterministic.
+		pool.Backends = map[model.BackendName]model.BackendConfig{
+			model.BackendARC: {
+				Enabled: true, Healthy: true, MaxRunners: 10, Weight: 1,
+				Capabilities: []string{"cluster-local"},
+			},
+			model.BackendCodeBuild: {
+				Enabled: true, Healthy: true, MaxRunners: 10, Weight: 3,
+				Capabilities: []string{"docker"},
+			},
+		}
+	})
+
+	want := []model.BackendName{
+		model.BackendARC,
+		model.BackendCodeBuild,
+		model.BackendCodeBuild,
+		model.BackendCodeBuild,
+	}
+	for index, expected := range want {
+		allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+			Pool:       model.PoolLite,
+			Tenant:     "tenant-a",
+			JobTimeout: 5 * time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("allocate #%d failed: %v", index+1, err)
+		}
+		if allocation.SelectedBackend != expected {
+			t.Fatalf("allocate #%d selected %s, want %s (weights under fairShare)", index+1, allocation.SelectedBackend, expected)
+		}
+		if _, ok := service.Cancel(allocation.ID); !ok {
+			t.Fatalf("cancel #%d failed", index+1)
+		}
+	}
+}
+
 func TestAllocateFailsForUnknownScheduler(t *testing.T) {
 	service := newServiceWithConfig(func(pool *model.PoolConfig) {
 		if pool.Name == model.PoolLite {

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1286,7 +1286,9 @@ func TestConcurrentAllocateDoesNotDoubleConsumeWarm(t *testing.T) {
 		codebuildCfg := pool.Backends[model.BackendCodeBuild]
 		codebuildCfg.Enabled = true
 		codebuildCfg.Healthy = true
-		codebuildCfg.MaxRunners = 2
+		// Warm prewarm holds 1 slot; concurrent workers each cold-reserve before
+		// warm claim, so MaxRunners must be >= 1(warm) + workers.
+		codebuildCfg.MaxRunners = 4
 		codebuildCfg.WarmMin = 1
 		codebuildCfg.WarmMax = 1
 		pool.Backends[model.BackendCodeBuild] = codebuildCfg

--- a/internal/scheduler/priority_fair_share.go
+++ b/internal/scheduler/priority_fair_share.go
@@ -96,7 +96,11 @@ func (s *priorityFairShareState) Reserve(pool model.PoolConfig, request model.Al
 		return *pinned, nil
 	}
 
-	backends := orderedBackends(pool)
+	// Compose with the pool backend scheduler: fair-share ranks by tenant/priority
+	// load, then WRR/RR order breaks ties among equal-score backends with capacity.
+	// When scheduler is weighted-round-robin, candidate order is weight-expanded so
+	// backend weights still influence selection when fair-share scores match.
+	backends := fairShareCandidateBackends(pool)
 	if len(backends) == 0 {
 		return "", ErrNoCapacity
 	}
@@ -141,6 +145,19 @@ func (s *priorityFairShareState) Reserve(pool model.PoolConfig, request model.Al
 	s.tenantActive[pool.Name][selected][tenant]++
 	s.cursors[pool.Name] = (bestIndex + 1) % len(backends)
 	return selected, nil
+}
+
+// fairShareCandidateBackends returns the ordered candidate ring used when
+// fair-share is selecting a backend. weighted-round-robin expands each backend
+// by its weight so weights apply as a tie-breaker among equal fair-share scores.
+// Other schedulers (round-robin, priority-fair-share) use one slot per backend.
+func fairShareCandidateBackends(pool model.PoolConfig) []model.BackendName {
+	switch normalizeSchedulerName(pool.Scheduler) {
+	case NameWeightedRoundRobin:
+		return weightedBackends(pool)
+	default:
+		return orderedBackends(pool)
+	}
 }
 
 func (s *priorityFairShareState) Release(pool model.PoolName, backend model.BackendName, allocation model.AllocationStatus) {

--- a/internal/scheduler/registry.go
+++ b/internal/scheduler/registry.go
@@ -20,8 +20,9 @@ type Scheduler interface {
 }
 
 type Registry struct {
-	defaultScheduler Scheduler
-	schedulers       map[string]Scheduler
+	defaultScheduler  Scheduler
+	schedulers        map[string]Scheduler
+	priorityFairShare *PriorityFairShare
 }
 
 func NewRegistry() *Registry {
@@ -30,13 +31,24 @@ func NewRegistry() *Registry {
 	priorityFairShare := NewPriorityFairShare()
 
 	return &Registry{
-		defaultScheduler: roundRobin,
+		defaultScheduler:  roundRobin,
+		priorityFairShare: priorityFairShare,
 		schedulers: map[string]Scheduler{
 			NameRoundRobin:         roundRobin,
 			NameWeightedRoundRobin: weightedRoundRobin,
 			NamePriorityFairShare:  priorityFairShare,
 		},
 	}
+}
+
+// PriorityFairShare returns the shared fair-share scheduler instance used both
+// when pools[].fairShare.enabled is true and when pools[].scheduler is
+// priority-fair-share. Sharing one instance avoids split active/tenant state.
+func (r *Registry) PriorityFairShare() *PriorityFairShare {
+	if r == nil || r.priorityFairShare == nil {
+		return NewPriorityFairShare()
+	}
+	return r.priorityFairShare
 }
 
 func (r *Registry) ForPool(pool model.PoolConfig) Scheduler {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -229,3 +229,100 @@ func TestPriorityFairShareEnforcesTenantQuotas(t *testing.T) {
 		t.Fatalf("reserve after release failed: %v", err)
 	}
 }
+
+func TestPriorityFairShareComposesWithWeightedRoundRobin(t *testing.T) {
+	scheduler := NewPriorityFairShare()
+	pool := poolByName(model.PoolLite)
+	pool.Scheduler = NameWeightedRoundRobin
+	pool.FairShare.Enabled = true
+	// Restrict to two backends so the weighted ring is deterministic.
+	pool.Backends = map[model.BackendName]model.BackendConfig{
+		model.BackendARC:       {Enabled: true, Healthy: true, MaxRunners: 10, Weight: 1},
+		model.BackendCodeBuild: {Enabled: true, Healthy: true, MaxRunners: 10, Weight: 3},
+	}
+
+	// Equal fair-share scores (release after each pick) → weights drive selection.
+	want := []model.BackendName{
+		model.BackendARC,
+		model.BackendCodeBuild,
+		model.BackendCodeBuild,
+		model.BackendCodeBuild,
+	}
+	for index, expected := range want {
+		selected, err := scheduler.Reserve(pool, allocationRequest(nil, "tenant-a", ""))
+		if err != nil {
+			t.Fatalf("reserve #%d failed: %v", index+1, err)
+		}
+		if selected != expected {
+			t.Fatalf("reserve #%d selected %s, want %s (weights should apply under fair-share)", index+1, selected, expected)
+		}
+		scheduler.Release(pool.Name, selected, model.AllocationStatus{Tenant: "tenant-a"})
+	}
+}
+
+func TestPriorityFairSharePrefersTenantBalanceOverWeights(t *testing.T) {
+	scheduler := NewPriorityFairShare()
+	pool := poolByName(model.PoolLite)
+	pool.Scheduler = NameWeightedRoundRobin
+	pool.FairShare.Enabled = true
+	pool.Backends = map[model.BackendName]model.BackendConfig{
+		// High weight on ARC must not override tenant load preference.
+		model.BackendARC:       {Enabled: true, Healthy: true, MaxRunners: 4, Weight: 10},
+		model.BackendCodeBuild: {Enabled: true, Healthy: true, MaxRunners: 4, Weight: 1},
+	}
+
+	pinned := model.BackendARC
+	for i := 0; i < 2; i++ {
+		if _, err := scheduler.Reserve(pool, allocationRequest(&pinned, "tenant-a", "")); err != nil {
+			t.Fatalf("setup reserve #%d failed: %v", i+1, err)
+		}
+	}
+
+	selected, err := scheduler.Reserve(pool, allocationRequest(nil, "tenant-b", ""))
+	if err != nil {
+		t.Fatalf("tenant-b reserve failed: %v", err)
+	}
+	if selected != model.BackendCodeBuild {
+		t.Fatalf("expected fair-share tenant balance to override weights, got %s", selected)
+	}
+}
+
+func TestPriorityFairShareWithRoundRobinIgnoresWeights(t *testing.T) {
+	scheduler := NewPriorityFairShare()
+	pool := poolByName(model.PoolLite)
+	pool.Scheduler = NameRoundRobin
+	pool.FairShare.Enabled = true
+	pool.Backends = map[model.BackendName]model.BackendConfig{
+		model.BackendARC:       {Enabled: true, Healthy: true, MaxRunners: 10, Weight: 1},
+		model.BackendCodeBuild: {Enabled: true, Healthy: true, MaxRunners: 10, Weight: 99},
+	}
+
+	// Equal scores + RR → one slot each, not weight-expanded.
+	want := []model.BackendName{
+		model.BackendARC,
+		model.BackendCodeBuild,
+		model.BackendARC,
+		model.BackendCodeBuild,
+	}
+	for index, expected := range want {
+		selected, err := scheduler.Reserve(pool, allocationRequest(nil, "tenant-a", ""))
+		if err != nil {
+			t.Fatalf("reserve #%d failed: %v", index+1, err)
+		}
+		if selected != expected {
+			t.Fatalf("reserve #%d selected %s, want %s", index+1, selected, expected)
+		}
+		scheduler.Release(pool.Name, selected, model.AllocationStatus{Tenant: "tenant-a"})
+	}
+}
+
+func TestRegistrySharesPriorityFairShareInstance(t *testing.T) {
+	registry := NewRegistry()
+	shared := registry.PriorityFairShare()
+	if shared == nil {
+		t.Fatal("expected shared PriorityFairShare instance")
+	}
+	if registry.ForName(NamePriorityFairShare) != shared {
+		t.Fatal("expected registry.ForName(priority-fair-share) to return the shared instance")
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Option A** for #65: fair-share composes with the pool backend scheduler instead of silently replacing it.

When `fairShare.enabled` is true:

1. **Tenant admission** — optional `fairShare.quotas`, tenant/priority accounting
2. **Fair-share ranking** — prefer lower active load and lower per-tenant usage
3. **Backend pick** — among equal-score backends with capacity, use the pool scheduler:
   - `weighted-round-robin` → weight-expanded candidate ring (weights apply)
   - `round-robin` / other → one slot per backend

## Changes

- `PriorityFairShare` uses weight-expanded candidates when `scheduler: weighted-round-robin`
- Share one `PriorityFairShare` instance via the scheduler registry (no dual-instance footgun)
- Document composition, quotas, and reserved `usageWindow`/`starvationAfter` in root README, architecture, multi-backend pack, and kustomize README
- Tests lock weight influence under fair-share and tenant-balance override of weights

## Tests

``` 
 go test ./internal/api/ ./internal/scheduler/ -count=1
``` 

- `TestPriorityFairShareComposesWithWeightedRoundRobin`
- `TestPriorityFairSharePrefersTenantBalanceOverWeights`
- `TestPriorityFairShareWithRoundRobinIgnoresWeights`
- `TestRegistrySharesPriorityFairShareInstance`
- `TestAllocateFairShareComposesWithWeightedRoundRobin`
- Existing fair-share / WRR-off paths unchanged

## Option chosen

**Option A** (compose). Multi-backend pack already advertised WRR + fairShare; behavior now matches docs.

Closes #65