### PR TITLE
fix: release fair-share capacity on warm consume (#61)

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -299,17 +299,25 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 	}
 
 	if warmAllocation, ok := s.consumeWarmAllocation(ctx, pool, selected, allocation); ok {
-		s.schedulerForPool(pool).Release(pool.Name, selected, allocation)
+		// Release the temporary cold reservation via the same counter path as
+		// reserve() so fair-share active counts do not leak when warm is hit.
+		s.release(context.Background(), pool, selected, allocation)
 		if err := s.store.Delete(allocation.ID); err != nil {
 			return model.AllocationStatus{}, err
 		}
 		launchMode = launchModeWarm
 		warmAllocation.State = model.StateReady
 		warmAllocation.CorrelationID = allocation.CorrelationID
+		previousTenant := warmAllocation.Tenant
 		warmAllocation.Tenant = request.Tenant
 		warmAllocation.PriorityClass = request.PriorityClass
 		warmAllocation.RequestedLabels = append([]string(nil), request.Labels...)
 		warmAllocation.ExpiresAt = allocation.ExpiresAt
+		// Warm slots are reserved under an empty tenant ("default"). Move the
+		// fair-share tenant accounting onto the consuming request identity.
+		if pool.FairShare.Enabled && s.fairShare != nil {
+			s.fairShare.ReassignTenant(pool.Name, selected, previousTenant, request.Tenant)
+		}
 		warmAllocation.Metadata = withLaunchModeMetadata(
 			backend.WithCapabilitiesMetadata(pool.Backends[selected], warmAllocation.Metadata),
 			launchMode,

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1227,6 +1227,72 @@ func TestAllocatePrefersWarmAllocationOverColdLaunch(t *testing.T) {
 	}
 }
 
+func TestWarmConsumeWithFairShareReleasesColdReservation(t *testing.T) {
+	now := time.Unix(1000, 0)
+	counting := &countingBackend{testBackend: testBackend{name: model.BackendCodeBuild}}
+	service := newServiceWithCountingBackend(func(pool *model.PoolConfig) {
+		if pool.Name != model.PoolLite {
+			return
+		}
+		pool.FairShare.Enabled = true
+		pool.Scheduler = "weighted-round-robin"
+		for name, backendCfg := range pool.Backends {
+			backendCfg.Enabled = false
+			pool.Backends[name] = backendCfg
+		}
+		codebuildCfg := pool.Backends[model.BackendCodeBuild]
+		codebuildCfg.Enabled = true
+		codebuildCfg.Healthy = true
+		codebuildCfg.MaxRunners = 4
+		codebuildCfg.WarmMin = 1
+		codebuildCfg.WarmMax = 1
+		pool.Backends[model.BackendCodeBuild] = codebuildCfg
+	}, counting)
+	service.now = func() time.Time { return now }
+
+	service.ReconcileWarmPools()
+	if got := service.fairShare.Active(model.PoolLite, model.BackendCodeBuild); got != 1 {
+		t.Fatalf("expected warm reservation to count as 1 active, got %d", got)
+	}
+	if got := service.fairShare.TenantActive(model.PoolLite, model.BackendCodeBuild, ""); got != 1 {
+		t.Fatalf("expected warm tenant active under default, got %d", got)
+	}
+
+	// Repeated warm-style hits should not permanently inflate fair-share active.
+	for i := 0; i < 3; i++ {
+		allocation, err := service.Allocate(context.Background(), model.AllocationRequest{
+			Pool:       model.PoolLite,
+			Tenant:     "team-a",
+			JobTimeout: 5 * time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("allocate #%d failed: %v", i+1, err)
+		}
+		if i == 0 {
+			if allocation.Metadata[backend.MetadataLaunchModeKey] != launchModeWarm {
+				t.Fatalf("expected first allocate to consume warm, got %q", allocation.Metadata[backend.MetadataLaunchModeKey])
+			}
+			if got := service.fairShare.Active(model.PoolLite, model.BackendCodeBuild); got != 1 {
+				t.Fatalf("after warm consume expected active=1 (warm only), got %d", got)
+			}
+			if got := service.fairShare.TenantActive(model.PoolLite, model.BackendCodeBuild, "team-a"); got != 1 {
+				t.Fatalf("expected tenant team-a active=1 after warm handoff, got %d", got)
+			}
+			if got := service.fairShare.TenantActive(model.PoolLite, model.BackendCodeBuild, ""); got != 0 {
+				t.Fatalf("expected default tenant active=0 after handoff, got %d", got)
+			}
+		}
+		if _, ok := service.Cancel(allocation.ID); !ok {
+			t.Fatalf("cancel #%d failed", i+1)
+		}
+		service.ReconcileWarmPools()
+	}
+
+	if got := service.fairShare.Active(model.PoolLite, model.BackendCodeBuild); got != 1 {
+		t.Fatalf("expected stable warm-only active count after warm hit cycle, got %d", got)
+	}
+}
+
 func TestFileStoreWarmConsumptionRehydratesOnlyRealAllocation(t *testing.T) {
 	statePath := t.TempDir() + "/allocations.json"
 	now := time.Unix(1000, 0)

--- a/internal/scheduler/priority_fair_share.go
+++ b/internal/scheduler/priority_fair_share.go
@@ -40,6 +40,18 @@ func (p *PriorityFairShare) Active(pool model.PoolName, backend model.BackendNam
 	return p.state.Active(pool, backend)
 }
 
+// ReassignTenant moves one unit of tenantActive from one tenant to another for
+// the given pool/backend without changing total active capacity. Used when a
+// warm allocation (reserved under the empty/"default" tenant) is handed off to
+// a real consumer identity.
+func (p *PriorityFairShare) ReassignTenant(pool model.PoolName, backend model.BackendName, from, to string) {
+	p.state.ReassignTenant(pool, backend, from, to)
+}
+
+func (p *PriorityFairShare) TenantActive(pool model.PoolName, backend model.BackendName, tenant string) int {
+	return p.state.TenantActive(pool, backend, tenant)
+}
+
 type priorityFairShareState struct {
 	mu           sync.Mutex
 	cursors      map[model.PoolName]int
@@ -175,6 +187,44 @@ func (s *priorityFairShareState) Active(pool model.PoolName, backend model.Backe
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.active[pool][backend]
+}
+
+func (s *priorityFairShareState) TenantActive(pool model.PoolName, backend model.BackendName, tenant string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tenantActive[pool][backend][normalizeTenant(tenant)]
+}
+
+func (s *priorityFairShareState) ReassignTenant(pool model.PoolName, backend model.BackendName, from, to string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fromTenant := normalizeTenant(from)
+	toTenant := normalizeTenant(to)
+	if fromTenant == toTenant {
+		return
+	}
+
+	if _, ok := s.tenantActive[pool]; !ok {
+		s.tenantActive[pool] = map[model.BackendName]map[string]int{}
+	}
+	fromCounts := s.tenantActive[pool][backend]
+	if fromCounts == nil {
+		fromCounts = map[string]int{}
+		s.tenantActive[pool][backend] = fromCounts
+	}
+	if fromCounts[fromTenant] > 0 {
+		fromCounts[fromTenant]--
+		if fromCounts[fromTenant] == 0 {
+			delete(fromCounts, fromTenant)
+		}
+	}
+	toCounts := s.tenantActive[pool][backend]
+	if toCounts == nil {
+		toCounts = map[string]int{}
+		s.tenantActive[pool][backend] = toCounts
+	}
+	toCounts[toTenant]++
 }
 
 func priorityFairShareScore(activeTotal, tenantActive, weight int) int {


### PR DESCRIPTION
## Summary
- On warm consume, release the temporary cold reservation via `s.release()` (same path as `reserve()`) so fair-share active counts do not leak
- Reassign fair-share tenant accounting from the warm `default` tenant to the consuming request tenant
- Add regression covering multi-backend-style fair-share + warm cycles

## Test plan
- [x] `go test ./internal/api ./internal/scheduler -run TestWarmConsumeWithFairShare|TestAllocatePrefersWarm -count=1`

Closes #61