### PR TITLE
fix: OIDC authorization policy and allocation ownership (IDOR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,46 @@ The token must include:
 - `sub`: a non-empty GitHub Actions subject such as `repo:OWNER/REPO:ref:...`
 - current `exp` and, when present, `nbf` claims
 
+Optional GitHub Actions claims used for authorization and ownership:
+
+- `repository` (`owner/repo`)
+- `repository_owner`
+- `workflow_ref` / `job_workflow_ref` (retained for future policy)
+
+### Authorization policy (`broker.api.oidcPolicy`)
+
+Authentication alone is not multi-tenant isolation. Configure an allowlist when
+the broker is reachable beyond a single trusted tenant:
+
+```yaml
+broker:
+  api:
+    oidcAudience: uecb-broker
+    oidcPolicy:
+      allowedRepositories:
+        - my-org/my-repo
+        - my-org/other-*
+      allowedOwners:
+        - my-org
+```
+
+- Empty `allowedRepositories` and `allowedOwners` (default): any **authenticated**
+  identity may allocate (backward compatible for single-tenant trusted deploys).
+- Non-empty lists: the caller's repository or owner must match at least one entry
+  (union). Patterns support a trailing `/*` (or `*`) wildcard.
+- Policy denial returns HTTP 403.
+
+### Allocation ownership (IDOR protection)
+
+On allocate, the broker stores the OIDC principal (`subject`, `repository`,
+`owner`) on the allocation. Get / cancel / complete require the same `sub` (or
+the same `repository` when both sides present it). Cross-tenant access returns
+HTTP 403. When `allowUnauthenticated` is true and the request has no bearer
+token, ownership checks are skipped so local/test modes keep working.
+
 Set `broker.allowUnauthenticated: true` only behind a separate trusted network
-or gateway boundary.
+or gateway boundary. For multi-tenant or internet-exposed brokers, keep
+authentication required and set a non-empty `oidcPolicy`.
 
 ## Azure Functions Launcher
 

--- a/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
+++ b/charts/unified-ephemeral-runner-broker/templates/configmap.yaml
@@ -30,6 +30,8 @@ data:
       allowUnauthenticated: {{ .Values.config.allowUnauthenticated }}
       api:
         oidcAudience: {{ .Values.config.broker.api.oidcAudience }}
+        oidcPolicy:
+{{ toYaml (.Values.config.broker.api.oidcPolicy | default dict) | indent 10 }}
       tierRouting:
 {{ toYaml .Values.config.broker.tierRouting | indent 8 }}
     pools:

--- a/charts/unified-ephemeral-runner-broker/values.yaml
+++ b/charts/unified-ephemeral-runner-broker/values.yaml
@@ -63,6 +63,13 @@ config:
       maxAttempts: 3
     api:
       oidcAudience: uecb-broker
+      # Empty allowlists keep any authenticated GitHub Actions identity allowed
+      # (backward compatible). Non-empty lists enforce a union match on
+      # repository (owner/repo) and/or owner. Patterns support trailing /*.
+      # Ownership (subject) is always bound on allocate when OIDC is used.
+      oidcPolicy:
+        allowedRepositories: []
+        allowedOwners: []
     tierRouting:
       enabled: false
       refreshInterval: 5m

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -67,11 +67,12 @@ func main() {
 		}
 		tier.StartRefreshLoop(context.Background(), tierManager, refresher, cfg.Broker.TierRouting.RefreshInterval)
 	}
-	server := api.NewServer(
+	server := api.NewServerWithPolicy(
 		service,
 		[]string{"https://token.actions.githubusercontent.com"},
 		cfg.Broker.API.OIDCAudience,
 		cfg.Broker.AllowUnauthenticated,
+		cfg.Broker.API.OIDCPolicy,
 	)
 
 	go func() {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -14,28 +14,70 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
 
 const oidcCacheTTL = time.Hour
 
 var (
-	ErrMissingBearerToken = errors.New("missing bearer token")
-	ErrInvalidBearerToken = errors.New("invalid bearer token")
-	ErrInvalidAudience    = errors.New("invalid oidc audience")
-	ErrInvalidIssuer      = errors.New("invalid oidc issuer")
-	ErrInvalidSubject     = errors.New("missing oidc subject")
-	ErrInvalidToken       = errors.New("invalid oidc token")
-	ErrInvalidSignature   = errors.New("invalid oidc token signature")
-	ErrTokenExpired       = errors.New("expired oidc token")
-	ErrTokenNotValidYet   = errors.New("oidc token not valid yet")
+	ErrMissingBearerToken  = errors.New("missing bearer token")
+	ErrInvalidBearerToken  = errors.New("invalid bearer token")
+	ErrInvalidAudience     = errors.New("invalid oidc audience")
+	ErrInvalidIssuer       = errors.New("invalid oidc issuer")
+	ErrInvalidSubject      = errors.New("missing oidc subject")
+	ErrInvalidToken        = errors.New("invalid oidc token")
+	ErrInvalidSignature    = errors.New("invalid oidc token signature")
+	ErrTokenExpired        = errors.New("expired oidc token")
+	ErrTokenNotValidYet    = errors.New("oidc token not valid yet")
+	ErrOIDCPolicyDenied    = errors.New("oidc identity is not allowed by policy")
+	ErrAllocationForbidden = errors.New("allocation access forbidden")
 )
 
+// OIDCClaims holds verified GitHub Actions OIDC identity claims used for
+// authentication, allowlist authorization, and allocation ownership binding.
 type OIDCClaims struct {
-	Iss string      `json:"iss"`
-	Aud interface{} `json:"aud"`
-	Sub string      `json:"sub"`
-	Exp int64       `json:"exp"`
-	Nbf int64       `json:"nbf,omitempty"`
+	Iss             string      `json:"iss"`
+	Aud             interface{} `json:"aud"`
+	Sub             string      `json:"sub"`
+	Exp             int64       `json:"exp"`
+	Nbf             int64       `json:"nbf,omitempty"`
+	Repository      string      `json:"repository,omitempty"`
+	RepositoryOwner string      `json:"repository_owner,omitempty"`
+	WorkflowRef     string      `json:"workflow_ref,omitempty"`
+	JobWorkflowRef  string      `json:"job_workflow_ref,omitempty"`
+}
+
+// EffectiveRepository returns the repository claim, or derives owner/repo from sub.
+func (c OIDCClaims) EffectiveRepository() string {
+	if repo := strings.TrimSpace(c.Repository); repo != "" {
+		return repo
+	}
+	// GitHub Actions sub formats: repo:OWNER/REPO:ref:..., repo:OWNER/REPO:environment:..., etc.
+	if !strings.HasPrefix(c.Sub, "repo:") {
+		return ""
+	}
+	rest := strings.TrimPrefix(c.Sub, "repo:")
+	parts := strings.SplitN(rest, ":", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	if strings.Contains(parts[0], "/") {
+		return parts[0]
+	}
+	return ""
+}
+
+// EffectiveOwner returns the repository owner claim, or derives it from repository/sub.
+func (c OIDCClaims) EffectiveOwner() string {
+	if owner := strings.TrimSpace(c.RepositoryOwner); owner != "" {
+		return owner
+	}
+	repo := c.EffectiveRepository()
+	if i := strings.Index(repo, "/"); i > 0 {
+		return repo[:i]
+	}
+	return ""
 }
 
 type OIDCVerifier struct {
@@ -197,6 +239,95 @@ func audienceMatches(value interface{}, expected string) bool {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+// AuthorizeOIDCPolicy enforces broker.api.oidcPolicy against verified claims.
+// Empty policy (no repositories and no owners) allows any authenticated identity.
+// When either allowlist is non-empty, the caller must match at least one entry.
+func AuthorizeOIDCPolicy(claims OIDCClaims, policy model.OIDCPolicyConfig) error {
+	repos := normalizeAllowlist(policy.AllowedRepositories)
+	owners := normalizeAllowlist(policy.AllowedOwners)
+	if len(repos) == 0 && len(owners) == 0 {
+		return nil
+	}
+
+	repository := claims.EffectiveRepository()
+	owner := claims.EffectiveOwner()
+
+	if len(repos) > 0 && matchAllowlist(repository, repos) {
+		return nil
+	}
+	if len(owners) > 0 && matchAllowlist(owner, owners) {
+		return nil
+	}
+	return ErrOIDCPolicyDenied
+}
+
+func normalizeAllowlist(entries []string) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func matchAllowlist(value string, patterns []string) bool {
+	if value == "" {
+		return false
+	}
+	for _, pattern := range patterns {
+		if matchAllowlistPattern(value, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchAllowlistPattern supports exact match and a single trailing "/*" or "*" wildcard.
+func matchAllowlistPattern(value, pattern string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasSuffix(pattern, "/*") {
+		prefix := strings.TrimSuffix(pattern, "/*")
+		if prefix == "" {
+			return true
+		}
+		return value == prefix || strings.HasPrefix(value, prefix+"/")
+	}
+	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		return strings.HasPrefix(value, prefix)
+	}
+	return value == pattern
+}
+
+// OwnershipAllows reports whether the caller may access an allocation.
+// Unbound allocations (no stored subject) remain readable by any authenticated
+// or anonymous caller. When a subject is bound, the caller must share the same
+// subject, or the same repository when both sides have a repository claim.
+func OwnershipAllows(claims OIDCClaims, status model.AllocationStatus) bool {
+	if status.Subject == "" {
+		return true
+	}
+	if claims.Sub == "" {
+		return false
+	}
+	if claims.Sub == status.Subject {
+		return true
+	}
+	repo := claims.EffectiveRepository()
+	if status.Repository != "" && repo != "" && status.Repository == repo {
+		return true
 	}
 	return false
 }

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -14,6 +14,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
 
 func TestVerifyTokenAcceptsSignedGitHubOIDCToken(t *testing.T) {
@@ -107,6 +109,90 @@ func TestValidateOIDCClaims(t *testing.T) {
 
 	if err := ValidateOIDCClaims(claims, "different", []string{"https://token.actions.githubusercontent.com"}); err != ErrInvalidAudience {
 		t.Fatalf("expected invalid audience error, got %v", err)
+	}
+}
+
+func TestOIDCClaimsEffectiveRepositoryAndOwner(t *testing.T) {
+	claims := OIDCClaims{
+		Sub:             "repo:acme/widgets:ref:refs/heads/main",
+		Repository:      "acme/widgets",
+		RepositoryOwner: "acme",
+	}
+	if claims.EffectiveRepository() != "acme/widgets" {
+		t.Fatalf("unexpected repository %q", claims.EffectiveRepository())
+	}
+	if claims.EffectiveOwner() != "acme" {
+		t.Fatalf("unexpected owner %q", claims.EffectiveOwner())
+	}
+
+	derived := OIDCClaims{Sub: "repo:acme/widgets:environment:prod"}
+	if derived.EffectiveRepository() != "acme/widgets" {
+		t.Fatalf("expected repo derived from sub, got %q", derived.EffectiveRepository())
+	}
+	if derived.EffectiveOwner() != "acme" {
+		t.Fatalf("expected owner derived from sub, got %q", derived.EffectiveOwner())
+	}
+}
+
+func TestAuthorizeOIDCPolicy(t *testing.T) {
+	claims := OIDCClaims{
+		Sub:             "repo:acme/widgets:ref:refs/heads/main",
+		Repository:      "acme/widgets",
+		RepositoryOwner: "acme",
+	}
+
+	if err := AuthorizeOIDCPolicy(claims, model.OIDCPolicyConfig{}); err != nil {
+		t.Fatalf("empty policy should allow: %v", err)
+	}
+	if err := AuthorizeOIDCPolicy(claims, model.OIDCPolicyConfig{
+		AllowedRepositories: []string{"acme/widgets"},
+	}); err != nil {
+		t.Fatalf("exact repository allowlist should allow: %v", err)
+	}
+	if err := AuthorizeOIDCPolicy(claims, model.OIDCPolicyConfig{
+		AllowedRepositories: []string{"acme/*"},
+	}); err != nil {
+		t.Fatalf("wildcard repository allowlist should allow: %v", err)
+	}
+	if err := AuthorizeOIDCPolicy(claims, model.OIDCPolicyConfig{
+		AllowedOwners: []string{"acme"},
+	}); err != nil {
+		t.Fatalf("owner allowlist should allow: %v", err)
+	}
+	if err := AuthorizeOIDCPolicy(claims, model.OIDCPolicyConfig{
+		AllowedRepositories: []string{"other/repo"},
+		AllowedOwners:       []string{"other-org"},
+	}); !errors.Is(err, ErrOIDCPolicyDenied) {
+		t.Fatalf("expected policy denial, got %v", err)
+	}
+	// Union: owner match is enough even when repository list does not match.
+	if err := AuthorizeOIDCPolicy(claims, model.OIDCPolicyConfig{
+		AllowedRepositories: []string{"other/repo"},
+		AllowedOwners:       []string{"acme"},
+	}); err != nil {
+		t.Fatalf("owner match should allow via union: %v", err)
+	}
+}
+
+func TestOwnershipAllows(t *testing.T) {
+	status := model.AllocationStatus{
+		Subject:    "repo:acme/widgets:ref:refs/heads/main",
+		Repository: "acme/widgets",
+	}
+	if !OwnershipAllows(OIDCClaims{Sub: status.Subject}, status) {
+		t.Fatal("same subject should be allowed")
+	}
+	if OwnershipAllows(OIDCClaims{Sub: "repo:other/repo:ref:refs/heads/main", Repository: "other/repo"}, status) {
+		t.Fatal("cross-tenant subject should be denied")
+	}
+	if !OwnershipAllows(OIDCClaims{Sub: "repo:acme/widgets:pull_request", Repository: "acme/widgets"}, status) {
+		t.Fatal("same repository should be allowed as ownership fallback")
+	}
+	if !OwnershipAllows(OIDCClaims{Sub: "anyone"}, model.AllocationStatus{}) {
+		t.Fatal("unbound allocation should allow any caller")
+	}
+	if OwnershipAllows(OIDCClaims{}, status) {
+		t.Fatal("empty subject should not access bound allocation")
 	}
 }
 

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -18,11 +18,17 @@ type Server struct {
 	allowedIssuers []string
 	expectedAud    string
 	allowAnon      bool
+	oidcPolicy     model.OIDCPolicyConfig
 	oidcVerifier   *OIDCVerifier
 	requests       *prometheus.CounterVec
 }
 
 func NewServer(service *Service, allowedIssuers []string, expectedAud string, allowAnon bool) *Server {
+	return NewServerWithPolicy(service, allowedIssuers, expectedAud, allowAnon, model.OIDCPolicyConfig{})
+}
+
+// NewServerWithPolicy constructs the API server with an OIDC repository/owner allowlist.
+func NewServerWithPolicy(service *Service, allowedIssuers []string, expectedAud string, allowAnon bool, policy model.OIDCPolicyConfig) *Server {
 	observer := NewPrometheusObserver(prometheus.DefaultRegisterer)
 	if err := observer.Register(prometheus.DefaultRegisterer); err != nil {
 		panic(err)
@@ -34,6 +40,7 @@ func NewServer(service *Service, allowedIssuers []string, expectedAud string, al
 		allowedIssuers: allowedIssuers,
 		expectedAud:    expectedAud,
 		allowAnon:      allowAnon,
+		oidcPolicy:     policy,
 		oidcVerifier:   NewOIDCVerifier(),
 		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "uecb_http_requests_total",
@@ -65,7 +72,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAllocations(w http.ResponseWriter, r *http.Request) {
-	if err := s.authorize(r); err != nil {
+	claims, err := s.authorize(r)
+	if err != nil {
+		if errors.Is(err, ErrOIDCPolicyDenied) {
+			s.writeError(w, http.StatusForbidden, err)
+			return
+		}
 		s.writeError(w, http.StatusUnauthorized, err)
 		return
 	}
@@ -77,7 +89,8 @@ func (s *Server) handleAllocations(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusBadRequest, err)
 			return
 		}
-		allocation, err := s.service.Allocate(r.Context(), request)
+		ctx := withPrincipal(r.Context(), claims)
+		allocation, err := s.service.Allocate(ctx, request)
 		if err != nil {
 			s.writeError(w, http.StatusBadRequest, err)
 			return
@@ -107,7 +120,12 @@ func retryAfterSeconds(retryAfter time.Time, now time.Time) string {
 }
 
 func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {
-	if err := s.authorize(r); err != nil {
+	claims, err := s.authorize(r)
+	if err != nil {
+		if errors.Is(err, ErrOIDCPolicyDenied) {
+			s.writeError(w, http.StatusForbidden, err)
+			return
+		}
 		s.writeError(w, http.StatusUnauthorized, err)
 		return
 	}
@@ -125,6 +143,10 @@ func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
 			return
 		}
+		if err := s.authorizeAllocationAccess(claims, id); err != nil {
+			s.writeOwnershipError(w, err)
+			return
+		}
 		status, ok := s.service.Cancel(id)
 		if !ok {
 			s.writeError(w, http.StatusNotFound, errors.New("allocation not found"))
@@ -139,6 +161,10 @@ func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {
 		id = strings.TrimSuffix(id, "/")
 		if r.Method != http.MethodPost {
 			s.writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+			return
+		}
+		if err := s.authorizeAllocationAccess(claims, id); err != nil {
+			s.writeOwnershipError(w, err)
 			return
 		}
 
@@ -169,6 +195,10 @@ func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.authorizeAllocationAccess(claims, path); err != nil {
+		s.writeOwnershipError(w, err)
+		return
+	}
 	status, ok := s.service.Get(path)
 	if !ok {
 		s.writeError(w, http.StatusNotFound, errors.New("allocation not found"))
@@ -177,24 +207,58 @@ func (s *Server) handleAllocationByID(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, http.StatusOK, status)
 }
 
-func (s *Server) authorize(r *http.Request) error {
+// authorize verifies the bearer token (when present) and enforces OIDC allowlist
+// policy for authenticated callers. Anonymous access is only permitted when
+// allowUnauthenticated is enabled.
+func (s *Server) authorize(r *http.Request) (OIDCClaims, error) {
 	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
 	if authHeader == "" {
 		if s.allowAnon {
-			return nil
+			return OIDCClaims{}, nil
 		}
-		return ErrMissingBearerToken
+		return OIDCClaims{}, ErrMissingBearerToken
 	}
 
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return ErrInvalidBearerToken
+		return OIDCClaims{}, ErrInvalidBearerToken
 	}
 	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
 	if token == "" {
-		return ErrInvalidBearerToken
+		return OIDCClaims{}, ErrInvalidBearerToken
 	}
-	_, err := s.oidcVerifier.VerifyToken(r.Context(), token, s.expectedAud, s.allowedIssuers)
-	return err
+	claims, err := s.oidcVerifier.VerifyToken(r.Context(), token, s.expectedAud, s.allowedIssuers)
+	if err != nil {
+		return OIDCClaims{}, err
+	}
+	if err := AuthorizeOIDCPolicy(claims, s.oidcPolicy); err != nil {
+		return OIDCClaims{}, err
+	}
+	return claims, nil
+}
+
+// authorizeAllocationAccess enforces ownership on get/cancel/complete.
+// When allowUnauthenticated is enabled and the request has no subject, ownership
+// checks are skipped so local/test modes and runner callbacks keep working.
+func (s *Server) authorizeAllocationAccess(claims OIDCClaims, id string) error {
+	if s.allowAnon && claims.Sub == "" {
+		return nil
+	}
+	status, ok := s.service.Get(id)
+	if !ok {
+		return ErrAllocationNotFound
+	}
+	if OwnershipAllows(claims, status) {
+		return nil
+	}
+	return ErrAllocationForbidden
+}
+
+func (s *Server) writeOwnershipError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrAllocationNotFound) {
+		s.writeError(w, http.StatusNotFound, err)
+		return
+	}
+	s.writeError(w, http.StatusForbidden, err)
 }
 
 func (s *Server) writeError(w http.ResponseWriter, code int, err error) {

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -155,11 +155,13 @@ func TestHandleAllocationsAcceptsSignedOIDCToken(t *testing.T) {
 	key := mustRSAKey(t)
 	issuer := configureSignedOIDC(t, server, key, "test-key", now)
 	token := signedOIDCToken(t, key, "test-key", OIDCClaims{
-		Iss: issuer.URL,
-		Aud: "uecb-broker",
-		Sub: "repo:example/repo:ref",
-		Exp: now.Add(time.Hour).Unix(),
-		Nbf: now.Add(-time.Minute).Unix(),
+		Iss:             issuer.URL,
+		Aud:             "uecb-broker",
+		Sub:             "repo:example/repo:ref:refs/heads/main",
+		Repository:      "example/repo",
+		RepositoryOwner: "example",
+		Exp:             now.Add(time.Hour).Unix(),
+		Nbf:             now.Add(-time.Minute).Unix(),
 	})
 
 	request := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
@@ -169,6 +171,143 @@ func TestHandleAllocationsAcceptsSignedOIDCToken(t *testing.T) {
 
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("expected signed token allocation to return 201, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	var allocation model.AllocationStatus
+	if err := json.NewDecoder(recorder.Body).Decode(&allocation); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if allocation.Subject != "repo:example/repo:ref:refs/heads/main" {
+		t.Fatalf("expected subject bound on allocation, got %q", allocation.Subject)
+	}
+	if allocation.Repository != "example/repo" {
+		t.Fatalf("expected repository bound on allocation, got %q", allocation.Repository)
+	}
+	if allocation.Owner != "example" {
+		t.Fatalf("expected owner bound on allocation, got %q", allocation.Owner)
+	}
+}
+
+func TestHandleAllocationsEnforcesOIDCPolicyAllowAndDeny(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+	server := newTestServer(t, service)
+	now := time.Unix(2000, 0)
+	key := mustRSAKey(t)
+	issuer := configureSignedOIDC(t, server, key, "test-key", now)
+	server.oidcPolicy = model.OIDCPolicyConfig{
+		AllowedRepositories: []string{"allowed/repo"},
+		AllowedOwners:       []string{"allowed-org"},
+	}
+
+	allowedToken := signedOIDCToken(t, key, "test-key", OIDCClaims{
+		Iss:             issuer.URL,
+		Aud:             "uecb-broker",
+		Sub:             "repo:allowed/repo:ref:refs/heads/main",
+		Repository:      "allowed/repo",
+		RepositoryOwner: "allowed",
+		Exp:             now.Add(time.Hour).Unix(),
+	})
+	deniedToken := signedOIDCToken(t, key, "test-key", OIDCClaims{
+		Iss:             issuer.URL,
+		Aud:             "uecb-broker",
+		Sub:             "repo:evil/repo:ref:refs/heads/main",
+		Repository:      "evil/repo",
+		RepositoryOwner: "evil",
+		Exp:             now.Add(time.Hour).Unix(),
+	})
+
+	allowedReq := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	allowedReq.Header.Set("Authorization", "Bearer "+allowedToken)
+	allowedRec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(allowedRec, allowedReq)
+	if allowedRec.Code != http.StatusCreated {
+		t.Fatalf("expected allowed repo to allocate, got %d: %s", allowedRec.Code, allowedRec.Body.String())
+	}
+
+	deniedReq := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	deniedReq.Header.Set("Authorization", "Bearer "+deniedToken)
+	deniedRec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(deniedRec, deniedReq)
+	if deniedRec.Code != http.StatusForbidden {
+		t.Fatalf("expected policy denial 403, got %d: %s", deniedRec.Code, deniedRec.Body.String())
+	}
+}
+
+func TestHandleAllocationRejectsCrossTenantOwnership(t *testing.T) {
+	service := newServiceWithConfig(nil)
+	service.now = func() time.Time { return time.Unix(1000, 0) }
+	server := newTestServer(t, service)
+	now := time.Unix(2000, 0)
+	key := mustRSAKey(t)
+	issuer := configureSignedOIDC(t, server, key, "test-key", now)
+
+	ownerClaims := OIDCClaims{
+		Iss:             issuer.URL,
+		Aud:             "uecb-broker",
+		Sub:             "repo:owner/repo:ref:refs/heads/main",
+		Repository:      "owner/repo",
+		RepositoryOwner: "owner",
+		Exp:             now.Add(time.Hour).Unix(),
+	}
+	otherClaims := OIDCClaims{
+		Iss:             issuer.URL,
+		Aud:             "uecb-broker",
+		Sub:             "repo:other/repo:ref:refs/heads/main",
+		Repository:      "other/repo",
+		RepositoryOwner: "other",
+		Exp:             now.Add(time.Hour).Unix(),
+	}
+	ownerToken := signedOIDCToken(t, key, "test-key", ownerClaims)
+	otherToken := signedOIDCToken(t, key, "test-key", otherClaims)
+
+	allocReq := httptest.NewRequest(http.MethodPost, "/v1/allocations", bytes.NewBufferString(`{"pool":"full","job_timeout":"15m"}`))
+	allocReq.Header.Set("Authorization", "Bearer "+ownerToken)
+	allocRec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(allocRec, allocReq)
+	if allocRec.Code != http.StatusCreated {
+		t.Fatalf("expected allocation 201, got %d: %s", allocRec.Code, allocRec.Body.String())
+	}
+	var allocation model.AllocationStatus
+	if err := json.NewDecoder(allocRec.Body).Decode(&allocation); err != nil {
+		t.Fatalf("decode allocation: %v", err)
+	}
+
+	// Cross-tenant get / cancel / complete must be rejected.
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "get", method: http.MethodGet, path: "/v1/allocations/" + allocation.ID},
+		{name: "cancel", method: http.MethodPost, path: "/v1/allocations/" + allocation.ID + "/cancel"},
+		{name: "complete", method: http.MethodPost, path: "/v1/allocations/" + allocation.ID + "/complete", body: `{"state":"completed"}`},
+	} {
+		req := httptest.NewRequest(tc.method, tc.path, bytes.NewBufferString(tc.body))
+		req.Header.Set("Authorization", "Bearer "+otherToken)
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("%s: expected 403 for cross-tenant access, got %d: %s", tc.name, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Owner can still get and complete.
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/allocations/"+allocation.ID, nil)
+	getReq.Header.Set("Authorization", "Bearer "+ownerToken)
+	getRec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("owner get expected 200, got %d: %s", getRec.Code, getRec.Body.String())
+	}
+
+	completeReq := httptest.NewRequest(http.MethodPost, "/v1/allocations/"+allocation.ID+"/complete", bytes.NewBufferString(`{"state":"completed"}`))
+	completeReq.Header.Set("Authorization", "Bearer "+ownerToken)
+	completeRec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(completeRec, completeReq)
+	if completeRec.Code != http.StatusOK {
+		t.Fatalf("owner complete expected 200, got %d: %s", completeRec.Code, completeRec.Body.String())
 	}
 }
 

--- a/internal/api/observability.go
+++ b/internal/api/observability.go
@@ -18,7 +18,10 @@ const (
 
 type contextKey string
 
-const correlationContextKey contextKey = correlationIDKey
+const (
+	correlationContextKey contextKey = correlationIDKey
+	principalContextKey   contextKey = "oidc_principal"
+)
 
 type Observer interface {
 	ObserveAllocationStart(model.PoolName)
@@ -276,6 +279,30 @@ func correlationIDFromContext(ctx context.Context) string {
 		return id
 	}
 	return ""
+}
+
+func withPrincipal(ctx context.Context, claims OIDCClaims) context.Context {
+	if claims.Sub == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, principalContextKey, claims)
+}
+
+func principalFromContext(ctx context.Context) (OIDCClaims, bool) {
+	claims, ok := ctx.Value(principalContextKey).(OIDCClaims)
+	if !ok || claims.Sub == "" {
+		return OIDCClaims{}, false
+	}
+	return claims, true
+}
+
+func applyPrincipal(status *model.AllocationStatus, claims OIDCClaims) {
+	if status == nil || claims.Sub == "" {
+		return
+	}
+	status.Subject = claims.Sub
+	status.Repository = claims.EffectiveRepository()
+	status.Owner = claims.EffectiveOwner()
 }
 
 func correlationIDFromRequest(r *http.Request) string {

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -310,6 +310,9 @@ func (s *Service) allocateNow(ctx context.Context, request model.AllocationReque
 		warmAllocation.PriorityClass = request.PriorityClass
 		warmAllocation.RequestedLabels = append([]string(nil), request.Labels...)
 		warmAllocation.ExpiresAt = allocation.ExpiresAt
+		warmAllocation.Subject = allocation.Subject
+		warmAllocation.Repository = allocation.Repository
+		warmAllocation.Owner = allocation.Owner
 		warmAllocation.Metadata = withLaunchModeMetadata(
 			backend.WithCapabilitiesMetadata(pool.Backends[selected], warmAllocation.Metadata),
 			launchMode,
@@ -389,6 +392,9 @@ func (s *Service) prepareAllocation(ctx context.Context, request model.Allocatio
 	allocation.Error = ""
 	requestCopy := request
 	allocation.Request = &requestCopy
+	if claims, ok := principalFromContext(ctx); ok {
+		applyPrincipal(&allocation, claims)
+	}
 	return allocation
 }
 
@@ -429,6 +435,9 @@ func (s *Service) queueAllocation(ctx context.Context, request model.AllocationR
 		status.Metadata = map[string]string{}
 	}
 	status.Metadata["queue_reason"] = queueReason(cause)
+	if claims, ok := principalFromContext(ctx); ok {
+		applyPrincipal(&status, claims)
+	}
 	_ = s.store.Save(status)
 	logAllocationEvent(ctx, "allocation_pending", map[string]string{
 		"allocation_id": allocationIDLabel(status.ID),

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -9,6 +9,40 @@ import (
 	"github.com/Josh-Archer/unified-ephemeral-runner-broker/internal/model"
 )
 
+func TestLoadParsesOIDCPolicy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broker.yaml")
+	if err := os.WriteFile(path, []byte(`
+broker:
+  api:
+    oidcAudience: custom-aud
+    oidcPolicy:
+      allowedRepositories:
+        - acme/widgets
+        - acme/*
+      allowedOwners:
+        - acme
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Broker.API.OIDCAudience != "custom-aud" {
+		t.Fatalf("unexpected audience %q", cfg.Broker.API.OIDCAudience)
+	}
+	if len(cfg.Broker.API.OIDCPolicy.AllowedRepositories) != 2 {
+		t.Fatalf("expected 2 allowed repositories, got %#v", cfg.Broker.API.OIDCPolicy.AllowedRepositories)
+	}
+	if cfg.Broker.API.OIDCPolicy.AllowedRepositories[0] != "acme/widgets" {
+		t.Fatalf("unexpected repository entry %#v", cfg.Broker.API.OIDCPolicy.AllowedRepositories)
+	}
+	if len(cfg.Broker.API.OIDCPolicy.AllowedOwners) != 1 || cfg.Broker.API.OIDCPolicy.AllowedOwners[0] != "acme" {
+		t.Fatalf("unexpected allowed owners %#v", cfg.Broker.API.OIDCPolicy.AllowedOwners)
+	}
+}
+
 func TestDefaultIncludesSeparateCodeBuildAndLambdaBackends(t *testing.T) {
 	cfg := Default()
 	pool := cfg.Pools[1]

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -69,8 +69,23 @@ type GitHubConfig struct {
 	Scope GitHubScope `yaml:"scope" json:"scope"`
 }
 
+// OIDCPolicyConfig restricts which GitHub Actions identities may allocate
+// runners. Empty lists are permissive (any authenticated subject is allowed).
+// When either list is non-empty, the caller's identity must match at least one
+// entry across the configured lists (union of repository and owner allowlists).
+//
+// Entries are exact matches, or simple trailing wildcards:
+//   - "owner/repo" exact repository
+//   - "owner/*"    any repository under owner
+//   - "owner"      exact owner (for allowedOwners)
+type OIDCPolicyConfig struct {
+	AllowedRepositories []string `yaml:"allowedRepositories,omitempty" json:"allowedRepositories,omitempty"`
+	AllowedOwners       []string `yaml:"allowedOwners,omitempty" json:"allowedOwners,omitempty"`
+}
+
 type BrokerAPIConfig struct {
-	OIDCAudience string `yaml:"oidcAudience" json:"oidcAudience"`
+	OIDCAudience string           `yaml:"oidcAudience" json:"oidcAudience"`
+	OIDCPolicy   OIDCPolicyConfig `yaml:"oidcPolicy,omitempty" json:"oidcPolicy,omitempty"`
 }
 
 type StateStoreConfig struct {
@@ -235,19 +250,23 @@ type AllocationRequest struct {
 }
 
 type AllocationStatus struct {
-	ID              string             `json:"allocation_id"`
-	CorrelationID   string             `json:"correlation_id,omitempty"`
-	Pool            PoolName           `json:"pool"`
-	SelectedBackend BackendName        `json:"selected_backend"`
-	RunnerLabel     string             `json:"runner_label"`
-	RequestedLabels []string           `json:"requested_labels,omitempty"`
-	Tenant          string             `json:"tenant,omitempty"`
-	PriorityClass   string             `json:"priority_class,omitempty"`
-	ExpiresAt       time.Time          `json:"expires_at"`
-	RetryAfter      time.Time          `json:"retry_after,omitempty"`
-	Attempts        int                `json:"attempts,omitempty"`
-	State           AllocationState    `json:"state"`
-	Error           string             `json:"error,omitempty"`
-	Metadata        map[string]string  `json:"metadata,omitempty"`
-	Request         *AllocationRequest `json:"request,omitempty"`
+	ID              string      `json:"allocation_id"`
+	CorrelationID   string      `json:"correlation_id,omitempty"`
+	Pool            PoolName    `json:"pool"`
+	SelectedBackend BackendName `json:"selected_backend"`
+	RunnerLabel     string      `json:"runner_label"`
+	RequestedLabels []string    `json:"requested_labels,omitempty"`
+	Tenant          string      `json:"tenant,omitempty"`
+	PriorityClass   string      `json:"priority_class,omitempty"`
+	// Subject/Repository/Owner bind the allocating OIDC principal for ownership checks.
+	Subject    string             `json:"subject,omitempty"`
+	Repository string             `json:"repository,omitempty"`
+	Owner      string             `json:"owner,omitempty"`
+	ExpiresAt  time.Time          `json:"expires_at"`
+	RetryAfter time.Time          `json:"retry_after,omitempty"`
+	Attempts   int                `json:"attempts,omitempty"`
+	State      AllocationState    `json:"state"`
+	Error      string             `json:"error,omitempty"`
+	Metadata   map[string]string  `json:"metadata,omitempty"`
+	Request    *AllocationRequest `json:"request,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Authorize GitHub Actions OIDC callers via configurable `broker.api.oidcPolicy` allowlists (`allowedRepositories`, `allowedOwners`); empty lists remain backward-compatible (any authenticated identity).
- Bind allocating principal (`subject`, `repository`, `owner`) on allocate and enforce same-subject (or same-repository) ownership on get/cancel/complete to close IDOR.
- Document policy + ownership in README and chart values/configmap.

## Design choices
- **Empty policy = permissive auth only**: no repo restriction for single-tenant trusted deploys; ownership still bound when `sub` is present.
- **Allowlist union**: match on repository *or* owner when either list is non-empty.
- **Patterns**: exact match plus trailing `/*` / `*` wildcards.
- **Ownership**: primary key is OIDC `sub`; fallback allows same `repository`. Unbound allocations (anon allocate) remain open.
- **`allowUnauthenticated`**: when no bearer token, skip ownership checks so local/test modes keep working.
- **Policy deny = 403**; ownership mismatch = 403; missing allocation = 404.

## Test plan
- [x] `go test ./internal/api/ ./internal/config/ -count=1`
- [x] Unit: policy allow/deny, ownership allow/deny, effective repo/owner from claims/sub
- [x] HTTP: signed allocate binds principal; policy deny 403; cross-tenant get/cancel/complete 403; owner happy path

Closes #62